### PR TITLE
docs: Revamp README for Windows 11 + PowerShell setup and operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,145 @@
-# 建物マップ（Tatemono Map）
+# Tatemono Map（建物/不動産データAPI MVP）
 
-北九州市（まずは小倉北区）を対象に、
-**Web＝建物ページ（マップ/図鑑）を量産（SEOの土台）**
-**LINE＝申込受付（刈り取り）**
-を“最小運用”で回すMVP。
+**目的**：建物/不動産データを扱うAPI MVP「tatemono-map」を、**Windows 11 + PowerShell 7.x** だけでローカル起動・運用できるようにするための手順書です。
 
 ---
 
-## MVPの固定方針（ここが憲法）
-- Web＝建物マップ（図鑑 / SEO土台）。**申込はしない**
-- LINE＝申込受付（入居日確定・初期費用合意・必要書類案内まで）
-- 号室はDBに保持しても **Webには出さない**
-- 見積（初期費用内訳PDF）は確度が高いユーザーにのみLINEで提示
-- 空室ステータスは **{空室あり / 満室} の2値**
-- 週2更新 + 最終更新日時で信用を担保（更新失敗でもWeb/LINEは落とさない）
-- 引き継ぎは「入居日確定 / 初期費用合意 / 必要書類案内済み」3点セット
+## 前提（必須）
+- OS：**Windows 11**
+- シェル：**PowerShell 7.x**
+- Python：**3.11 以上**（`py -0` で確認）
+- Git：インストール済み（`git --version`）
+
+> **OneDrive 外で開発すること**
+> - **理由**：OneDrive の同期/ロックが仮想環境や `.venv` の作成・更新を不安定にするためです。
+> - 例：`C:\dev\tatemono-map` に clone し、Desktop には **ショートカットだけ**置く運用を推奨します。
 
 ---
 
-## 成果物（段階）
-- Phase2 PoC：Gmail → URL抽出 → HTML取得 → 最小項目抽出 → DB upsert（週2）
-- Web：建物ページテンプレ1枚（Map Embed + 募集サマリー + LINE CTA）
-- 失敗時：管理者へLINE通知（落とさない）
+## 初回セットアップ（Windows + PowerShell 完結）
+以下は **PowerShell にコピペ実行**できます（改行/`;` どちらでも可）。
 
----
+### 1) リポジトリを取得
+```powershell
+mkdir C:\dev ; cd C:\dev
+git clone https://github.com/<your-org>/tatemono-map.git
+cd .\tatemono-map
+```
 
-## ローカル起動（必ず repo 直下で）
-### 1) セットアップ
-scripts\dev_setup.ps1
+### 2) venv 作成・有効化
+```powershell
+py -3.11 -m venv .venv
+. .\.venv\Scripts\Activate.ps1
+```
 
-### 2) API起動
-scripts\run_api.ps1
-- http://127.0.0.1:8000/health
+### 3) 依存インストール
+```powershell
+python -m pip install -U pip
+pip install -r requirements.txt
+pip install -e .
+```
+
+### 4) 起動（API）
+```powershell
+uvicorn tatemono_map.api.main:app --reload --host 127.0.0.1 --port 8000
+```
+
+### 5) 動作確認（/health など）
+別ターミナルで実行：
+```powershell
+Invoke-RestMethod http://127.0.0.1:8000/health
+```
+期待されるレスポンス：
+```json
+{"ok": true}
+```
+
+ブラウザ確認：
+- http://127.0.0.1:8000/
 - http://127.0.0.1:8000/b/demo
 
-### 3) 取り込み（週2想定・今はスタブ）
-scripts\run_ingest.ps1
+---
+
+## .env / secrets の扱い（重要）
+- **secrets/.env はコミットしない**でください。
+- 推奨：`.env.example` を作り、**安全な値だけ**をサンプルとして共有します。
+- 実運用の `.env` は **ローカルだけ**に保存してください。
 
 ---
 
-## 仕様の正本
-- docs/spec.md
-- docs/data_contract.md
-- docs/runbook.md
+## よくある詰まり（FAQ）
+
+### Q1. `fatal: not a git repository`
+**原因**：リポジトリ直下にいない。
+**対処**：`cd` で `tatemono-map` 直下へ移動してから再実行。
+```powershell
+cd C:\dev\tatemono-map
+git status
+```
+
+### Q2. `Address already in use`（ポート競合）
+**原因**：8000番ポートが他プロセスで使用中。
+**対処**：空いているポートで起動。
+```powershell
+uvicorn tatemono_map.api.main:app --reload --host 127.0.0.1 --port 8010
+```
+
+### Q3. `Activate.ps1` で venv が有効化できない
+**原因**：PowerShell の実行ポリシー。
+**対処**：現在のユーザーだけ許可して再実行。
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+. .\.venv\Scripts\Activate.ps1
+```
+
+### Q4. `ModuleNotFoundError` / `No module named ...`
+**原因**：依存インストール漏れ、または venv 未有効化。
+**対処**：venv を有効化して再インストール。
+```powershell
+. .\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+pip install -e .
+```
+
+### Q5. `ERR_CONNECTION_REFUSED`（ブラウザで接続不可）
+**原因**：API が起動していない、またはポートが異なる。
+**対処**：起動コマンドとポートを再確認。
+```powershell
+uvicorn tatemono_map.api.main:app --reload --host 127.0.0.1 --port 8000
+```
+
+---
+
+## 仕様・ドキュメント
+- `docs/spec.md`
+- `docs/data_contract.md`
+- `docs/runbook.md`
+
+---
+
+## 一発 PowerShell コマンド集（README 末尾）
+
+### 1) 日常更新：pull → 変更確認 → add → commit → push
+```powershell
+git pull
+; git status
+; git add -A
+; git commit -m "chore: update"
+; git push
+```
+
+### 2) PR運用：feature ブランチ作成 → push → PR → mainへマージ → pull
+```powershell
+$branch = "feature/your-topic"
+; git checkout -b $branch
+; git push -u origin $branch
+; # PR を作成（GitHub などのUIで）
+; # PR を main にマージ
+; git checkout main
+; git pull
+```
+
+### 3) 起動：uvicorn 実行（必要なら --reload / host / port）
+```powershell
+uvicorn tatemono_map.api.main:app --reload --host 127.0.0.1 --port 8000
+```


### PR DESCRIPTION
### Motivation
- Make the project runnable and maintainable on a developer machine using only `Windows 11` and `PowerShell 7.x` by providing a clear, copy-pasteable README for local operations.
- Reduce common Windows-specific setup friction (venv activation, execution policy, OneDrive interference, port conflicts) so contributors can get the API running quickly.
- Ensure secrets handling and typical Git/PR workflows are documented for safe local development and everyday maintenance.

### Description
- Fully rewrote `README.md` to target `Windows 11 + PowerShell 7.x` with prerequisites and a short OneDrive guidance (recommend using `C:\dev\tatemono-map` and placing only a Desktop shortcut).
- Added step-by-step initial setup instructions including `git clone`, virtualenv creation/activation with `py -3.11 -m venv .venv` and `. .\.venv\Scripts\Activate.ps1`, dependency installation with `pip install -r requirements.txt` and `pip install -e .`, and API startup with `uvicorn tatemono_map.api.main:app --reload --host 127.0.0.1 --port 8000`.
- Inserted a troubleshooting FAQ covering `not a git repository`, port conflicts (`Address already in use`), `Activate.ps1` execution policy, `ModuleNotFoundError`, and `ERR_CONNECTION_REFUSED` with concrete `PowerShell` commands to resolve each issue.
- Added `.env` / secrets guidance recommending `secrets/.env` not be committed and to provide a ` .env.example`, and appended a PowerShell one-liner command collection for daily updates, PR workflow, and starting the API.

### Testing
- No automated tests were run because this is a documentation-only change and does not modify runtime code or automated test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e525417d48326b2bb456f1742a7a1)