### PR TITLE
feat: implement /health endpoint with optional DB check and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Invoke-RestMethod http://127.0.0.1:8000/health
 ```
 期待されるレスポンス：
 ```json
-{"ok": true}
+{"status": "ok", "app": "Tatemono Map", "time": "2024-01-01T00:00:00+00:00"}
 ```
 
 ブラウザ確認：

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ selectolax
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
+httpx

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from tatemono_map.api.main import app
+
+
+def test_health_returns_ok():
+    client = TestClient(app)
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"


### PR DESCRIPTION
### Motivation
- Provide a minimal, reliable `/health` endpoint for the FastAPI MVP that always responds on startup and is easy to check from Windows PowerShell.
- Ensure the health check includes basic metadata (`status`, `app`, `time`) and performs a lightweight DB probe only when `DATABASE_URL` is configured so the endpoint never crashes when DB is unset.

### Description
- Implemented `GET /health` in `src/tatemono_map/api/main.py` to return `status`, `app`, and UTC `time` in ISO format and to optionally include a `db` field from a lightweight `_db_status()` check using `sqlalchemy.create_engine`.
- The DB probe returns `None` (omits `db`) when `DATABASE_URL` is not set and returns `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e5c450a748326acdc0bbc6220fad5)