### PR TITLE
docs: clarify PowerShell quick commands for Codex-first workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,20 @@ uvicorn tatemono_map.api.main:app --reload --host 127.0.0.1 --port 8000
 
 ## 一発 PowerShell コマンド集（README 末尾）
 
-### 1) 日常更新：pull → 変更確認 → add → commit → push
+### 1) 日常更新：基本は Codex → GitHub merge → ローカル pull で確認
+**⚠️ 注意：`On branch main` などの「出力」はコマンドではないので貼り付けない**
+
+#### (A) 基本フロー（Codex運用）：GitHubでmerge後にローカルで pull して動作確認
 ```powershell
-git pull
+cd C:\dev\tatemono-map
+; git pull
 ; git status
+; # 変更内容を確認してローカルで動作確認
+```
+
+#### (B) 例外（ローカルで変更した場合のみ）：add → commit → push
+```powershell
+cd C:\dev\tatemono-map
 ; git add -A
 ; git commit -m "chore: update"
 ; git push
@@ -130,7 +140,8 @@ git pull
 
 ### 2) PR運用：feature ブランチ作成 → push → PR → mainへマージ → pull
 ```powershell
-$branch = "feature/your-topic"
+cd C:\dev\tatemono-map
+; $branch = "feature/your-topic"
 ; git checkout -b $branch
 ; git push -u origin $branch
 ; # PR を作成（GitHub などのUIで）
@@ -141,5 +152,6 @@ $branch = "feature/your-topic"
 
 ### 3) 起動：uvicorn 実行（必要なら --reload / host / port）
 ```powershell
-uvicorn tatemono_map.api.main:app --reload --host 127.0.0.1 --port 8000
+cd C:\dev\tatemono-map
+; uvicorn tatemono_map.api.main:app --reload --host 127.0.0.1 --port 8000
 ```


### PR DESCRIPTION
### Motivation
- Align the quick PowerShell instructions with the current Codex→PR→merge→local-pull workflow and reduce accidental local mistakes.
- Emphasize that local `add/commit/push` is an exception used only when changes are made locally.
- Prevent users from pasting command output (e.g. `On branch main`) as commands by adding a short, visible warning.

### Description
- Updated `README.md` quick-commands section to split the daily update flow into (A) Codex-first pull/verify and (B) local-change exception paths.  
- Added a prominent one-line warning that outputs like `On branch main` are not commands.  
- Made the examples safer to copy/paste by adding explicit `cd C:\dev\tatemono-map` steps to the quick command blocks and adjusted the PR and `uvicorn` examples accordingly.

### Testing
- No automated tests were run because this is a documentation-only change; changes were reviewed locally in the `README.md` file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e5fdd01208326a6f4e8aad654444f)