### PR TITLE
docs: make PowerShell command blocks self-contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,16 @@ uvicorn tatemono_map.api.main:app --reload --host 127.0.0.1 --port 8000
 **⚠️ 注意：`On branch main` などの「出力」はコマンドではないので貼り付けない**
 
 ```powershell
-$REPO = "$env:USERPROFILE\tatemono-map"
-; cd $REPO
-; if (-not (Test-Path .git)) { Write-Host "Not a git repository. Check $REPO." ; return }
+$REPO = Join-Path $env:USERPROFILE "tatemono-map"
+if (!(Test-Path (Join-Path $REPO ".git"))) { throw "Not a git repository: $REPO" }
+Set-Location $REPO
 ```
 
 #### (A) 基本フロー（Codex運用）：GitHubでmerge後にローカルで pull して動作確認
 ```powershell
-cd $REPO
+$REPO = Join-Path $env:USERPROFILE "tatemono-map"
+if (!(Test-Path (Join-Path $REPO ".git"))) { throw "Not a git repository: $REPO" }
+Set-Location $REPO
 ; git pull
 ; git status
 ; # 変更内容を確認してローカルで動作確認
@@ -138,7 +140,9 @@ cd $REPO
 
 #### (B) 例外（ローカルで変更した場合のみ）：add → commit → push
 ```powershell
-cd $REPO
+$REPO = Join-Path $env:USERPROFILE "tatemono-map"
+if (!(Test-Path (Join-Path $REPO ".git"))) { throw "Not a git repository: $REPO" }
+Set-Location $REPO
 ; git add -A
 ; git commit -m "chore: update"
 ; git push
@@ -146,7 +150,9 @@ cd $REPO
 
 ### 2) PR運用：feature ブランチ作成 → push → PR → mainへマージ → pull
 ```powershell
-cd $REPO
+$REPO = Join-Path $env:USERPROFILE "tatemono-map"
+if (!(Test-Path (Join-Path $REPO ".git"))) { throw "Not a git repository: $REPO" }
+Set-Location $REPO
 ; $branch = "feature/your-topic"
 ; git checkout -b $branch
 ; git push -u origin $branch
@@ -158,6 +164,8 @@ cd $REPO
 
 ### 3) 起動：uvicorn 実行（必要なら --reload / host / port）
 ```powershell
-cd $REPO
+$REPO = Join-Path $env:USERPROFILE "tatemono-map"
+if (!(Test-Path (Join-Path $REPO ".git"))) { throw "Not a git repository: $REPO" }
+Set-Location $REPO
 ; uvicorn tatemono_map.api.main:app --reload --host 127.0.0.1 --port 8000
 ```


### PR DESCRIPTION
### Motivation
- Prevent accidental execution of git commands outside the repository when users copy-paste an individual PowerShell block by ensuring each block always moves into the repo first.
- Avoid reliance on a pre-defined `$REPO` variable so blocks are safe to run standalone and do not produce `fatal: not a git repository` errors.

### Description
- Prepends each PowerShell code block in the "一発 PowerShell コマンド集（README 末尾）" section with ` $REPO = Join-Path $env:USERPROFILE "tatemono-map"`, a `.git` existence check using `Test-Path` and a `Set-Location $REPO` call so blocks are self-contained.
- Replaces previous path usage with `Join-Path` and removes any fixed absolute paths so no repo-specific hardcoded paths remain.
- Preserves the existing warning about not pasting command output like `On branch main` and confines changes to `README.md` only.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e668daaf4832689eac126a8e910c9)