### PR TITLE
Add SQLite-backed Building CRUD API with search and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.pyc
 .env
 data/*.db
+data/*.sqlite3
 secrets/
 .vscode/
 .idea/

--- a/src/tatemono_map/api/database.py
+++ b/src/tatemono_map/api/database.py
@@ -1,0 +1,58 @@
+import os
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+Base = declarative_base()
+
+_ENGINE = None
+_DB_PATH: Path | None = None
+
+
+def _resolve_db_path() -> Path:
+    env_path = os.getenv("SQLITE_DB_PATH")
+    if env_path:
+        return Path(env_path).expanduser().resolve()
+
+    repo_root = Path(__file__).resolve().parents[3]
+    return repo_root / "data" / "tatemono_map.sqlite3"
+
+
+def _get_database_url(db_path: Path) -> str:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    return f"sqlite+pysqlite:///{db_path.as_posix()}"
+
+
+def get_engine():
+    global _ENGINE
+    global _DB_PATH
+
+    db_path = _resolve_db_path()
+    if _ENGINE is None or _DB_PATH != db_path:
+        _DB_PATH = db_path
+        _ENGINE = create_engine(
+            _get_database_url(db_path),
+            connect_args={"check_same_thread": False},
+        )
+
+    return _ENGINE
+
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False)
+
+
+def init_db() -> None:
+    from tatemono_map.models import building  # noqa: F401
+
+    engine = get_engine()
+    Base.metadata.create_all(bind=engine)
+
+
+def reset_engine() -> None:
+    global _ENGINE
+    global _DB_PATH
+    if _ENGINE is not None:
+        _ENGINE.dispose()
+    _ENGINE = None
+    _DB_PATH = None

--- a/src/tatemono_map/api/main.py
+++ b/src/tatemono_map/api/main.py
@@ -1,11 +1,17 @@
 import os
 from datetime import datetime, timezone
+from typing import Annotated
 from pathlib import Path
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response, status
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from tatemono_map.api.database import SessionLocal, get_engine, init_db
+from tatemono_map.api.schemas import BuildingCreate, BuildingRead, BuildingUpdate
+from tatemono_map.models.building import Building
 
 app = FastAPI(title="Tatemono Map")
 
@@ -15,7 +21,12 @@ templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 def _db_status() -> str | None:
     database_url = os.getenv("DATABASE_URL")
     if not database_url:
-        return None
+        try:
+            engine = get_engine()
+            with engine.connect():
+                return "ok"
+        except Exception:
+            return "error"
 
     try:
         engine = create_engine(database_url, pool_pre_ping=False)
@@ -38,6 +49,107 @@ def health():
         payload["db"] = db_status
 
     return payload
+
+
+def get_db() -> Session:
+    init_db()
+    db = SessionLocal(bind=get_engine())
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+DbSession = Annotated[Session, Depends(get_db)]
+
+
+def _apply_search_filters(query, q: str | None, min_lat: float | None, max_lat: float | None,
+                          min_lng: float | None, max_lng: float | None):
+    if q:
+        like_query = f"%{q}%"
+        query = query.filter(
+            (Building.name.ilike(like_query)) | (Building.address.ilike(like_query))
+        )
+    if min_lat is not None:
+        query = query.filter(Building.lat >= min_lat)
+    if max_lat is not None:
+        query = query.filter(Building.lat <= max_lat)
+    if min_lng is not None:
+        query = query.filter(Building.lng >= min_lng)
+    if max_lng is not None:
+        query = query.filter(Building.lng <= max_lng)
+    return query
+
+
+@app.post("/buildings", response_model=BuildingRead, status_code=status.HTTP_201_CREATED)
+def create_building(payload: BuildingCreate, db: DbSession):
+    now = datetime.now(timezone.utc)
+    building = Building(
+        name=payload.name,
+        address=payload.address,
+        lat=payload.lat,
+        lng=payload.lng,
+        building_type=payload.building_type,
+        floors=payload.floors,
+        year_built=payload.year_built,
+        source=payload.source,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(building)
+    db.commit()
+    db.refresh(building)
+    return building
+
+
+@app.get("/buildings", response_model=list[BuildingRead])
+def list_buildings(
+    db: DbSession,
+    limit: Annotated[int, Query(ge=1, le=100)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+    q: str | None = None,
+    min_lat: float | None = None,
+    max_lat: float | None = None,
+    min_lng: float | None = None,
+    max_lng: float | None = None,
+):
+    query = db.query(Building)
+    query = _apply_search_filters(query, q, min_lat, max_lat, min_lng, max_lng)
+    query = query.order_by(Building.id).offset(offset).limit(limit)
+    return query.all()
+
+
+@app.get("/buildings/{building_id}", response_model=BuildingRead)
+def get_building(building_id: int, db: DbSession):
+    building = db.get(Building, building_id)
+    if not building:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Building not found")
+    return building
+
+
+@app.patch("/buildings/{building_id}", response_model=BuildingRead)
+def update_building(building_id: int, payload: BuildingUpdate, db: DbSession):
+    building = db.get(Building, building_id)
+    if not building:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Building not found")
+    data = payload.model_dump(exclude_unset=True)
+    for key, value in data.items():
+        setattr(building, key, value)
+    building.updated_at = datetime.now(timezone.utc)
+    db.add(building)
+    db.commit()
+    db.refresh(building)
+    return building
+
+
+@app.delete("/buildings/{building_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_building(building_id: int, db: DbSession):
+    building = db.get(Building, building_id)
+    if not building:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Building not found")
+    db.delete(building)
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 @app.get("/", response_class=HTMLResponse)
 def index(request: Request):

--- a/src/tatemono_map/api/schemas.py
+++ b/src/tatemono_map/api/schemas.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class BuildingBase(BaseModel):
+    name: str = Field(..., min_length=1)
+    address: str = Field(..., min_length=1)
+    lat: float
+    lng: float
+    building_type: str | None = None
+    floors: int | None = None
+    year_built: int | None = None
+    source: str | None = None
+
+    @field_validator("lat")
+    @classmethod
+    def validate_lat(cls, value: float) -> float:
+        if value < -90 or value > 90:
+            raise ValueError("lat must be between -90 and 90")
+        return value
+
+    @field_validator("lng")
+    @classmethod
+    def validate_lng(cls, value: float) -> float:
+        if value < -180 or value > 180:
+            raise ValueError("lng must be between -180 and 180")
+        return value
+
+
+class BuildingCreate(BuildingBase):
+    pass
+
+
+class BuildingUpdate(BaseModel):
+    name: str | None = None
+    address: str | None = None
+    lat: float | None = None
+    lng: float | None = None
+    building_type: str | None = None
+    floors: int | None = None
+    year_built: int | None = None
+    source: str | None = None
+
+    @field_validator("lat")
+    @classmethod
+    def validate_lat(cls, value: float | None) -> float | None:
+        if value is None:
+            return value
+        if value < -90 or value > 90:
+            raise ValueError("lat must be between -90 and 90")
+        return value
+
+    @field_validator("lng")
+    @classmethod
+    def validate_lng(cls, value: float | None) -> float | None:
+        if value is None:
+            return value
+        if value < -180 or value > 180:
+            raise ValueError("lng must be between -180 and 180")
+        return value
+
+
+class BuildingRead(BuildingBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/src/tatemono_map/models/building.py
+++ b/src/tatemono_map/models/building.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from tatemono_map.api.database import Base
+
+
+class Building(Base):
+    __tablename__ = "buildings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    address: Mapped[str] = mapped_column(String(255), nullable=False)
+    lat: Mapped[float] = mapped_column(Float, nullable=False)
+    lng: Mapped[float] = mapped_column(Float, nullable=False)
+    building_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    floors: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    year_built: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    source: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+sys.path.insert(0, str(SRC))

--- a/tests/test_buildings.py
+++ b/tests/test_buildings.py
@@ -1,0 +1,103 @@
+from fastapi.testclient import TestClient
+
+
+def _create_building(client: TestClient, **overrides):
+    payload = {
+        "name": "Sample Building",
+        "address": "1-2-3 Example Street",
+        "lat": 35.0,
+        "lng": 139.0,
+        "building_type": "office",
+        "floors": 10,
+        "year_built": 1999,
+        "source": "manual",
+    }
+    payload.update(overrides)
+    response = client.post("/buildings", json=payload)
+    assert response.status_code == 201
+    return response.json()
+
+
+def _get_client(tmp_path, monkeypatch) -> TestClient:
+    db_path = tmp_path / "test.sqlite3"
+    monkeypatch.setenv("SQLITE_DB_PATH", str(db_path))
+
+    from tatemono_map.api import database
+
+    database.reset_engine()
+    database.init_db()
+
+    from tatemono_map.api.main import app
+
+    return TestClient(app)
+
+
+def test_create_and_get_building(tmp_path, monkeypatch):
+    client = _get_client(tmp_path, monkeypatch)
+    created = _create_building(client)
+
+    response = client.get(f"/buildings/{created['id']}")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["name"] == "Sample Building"
+    assert data["address"] == "1-2-3 Example Street"
+
+
+def test_list_buildings_with_limit_offset(tmp_path, monkeypatch):
+    client = _get_client(tmp_path, monkeypatch)
+    first = _create_building(client, name="First", address="Alpha")
+    second = _create_building(client, name="Second", address="Beta")
+    _create_building(client, name="Third", address="Gamma")
+
+    response = client.get("/buildings?limit=1&offset=1")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert len(data) == 1
+    assert data[0]["id"] == second["id"]
+    assert data[0]["name"] == second["name"]
+    assert first["id"] != second["id"]
+
+
+def test_search_buildings_by_query(tmp_path, monkeypatch):
+    client = _get_client(tmp_path, monkeypatch)
+    _create_building(client, name="Sakura Tower", address="Tokyo Central")
+    _create_building(client, name="Ume House", address="Osaka")
+
+    response = client.get("/buildings?q=Tokyo")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert len(data) == 1
+    assert data[0]["name"] == "Sakura Tower"
+
+
+def test_search_buildings_by_bbox(tmp_path, monkeypatch):
+    client = _get_client(tmp_path, monkeypatch)
+    in_box = _create_building(client, name="Inside", lat=35.5, lng=139.5)
+    _create_building(client, name="Outside", lat=40.0, lng=140.0)
+
+    response = client.get(
+        "/buildings?min_lat=35.0&max_lat=36.0&min_lng=139.0&max_lng=140.0"
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    assert len(data) == 1
+    assert data[0]["id"] == in_box["id"]
+
+
+def test_update_building(tmp_path, monkeypatch):
+    client = _get_client(tmp_path, monkeypatch)
+    created = _create_building(client, name="Old Name")
+
+    response = client.patch(
+        f"/buildings/{created['id']}",
+        json={"name": "New Name", "floors": 12},
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["name"] == "New Name"
+    assert data["floors"] == 12


### PR DESCRIPTION
### Motivation
- Provide persistent storage for Building data via SQLite with an API exposing minimal CRUD and search functionality.
- Support simple text search (`q`) and bounding-box filters (`min_lat`/`max_lat`/`min_lng`/`max_lng`) plus pagination (`limit`/`offset`).

### Description
- Add database utilities in `src/tatemono_map/api/database.py` that resolve `SQLITE_DB_PATH` (fallback `data/tatemono_map.sqlite3`), create the engine (`sqlite+pysqlite`), and expose `get_engine()`, `SessionLocal`, `init_db()`, and `reset_engine()`.
- Implement SQLAlchemy `Building` model in `src/tatemono_map/models/building.py` with fields `id, name, address, lat, lng, building_type, floors, year_built, source, created_at, updated_at`.
- Add Pydantic schemas in `src/tatemono_map/api/schemas.py` separating `BuildingCreate`, `BuildingUpdate`, and `BuildingRead` and include lat/lng range validators.
- Implement endpoints in `src/tatemono_map/api/main.py`: `POST /buildings`, `GET /buildings` (with `limit`, `offset`, `q`, bbox filters), `GET /buildings/{id}`, `PATCH /buildings/{id}`, and `DELETE /buildings/{id}`, wired to the SQLite session and creating tables on demand via `init_db()`.
- Add tests `tests/test_buildings.py` and test helper `tests/conftest.py`, and update `.gitignore` to ignore generated DB files (`data/*.sqlite3`).

### Testing
- Ran `pytest` against the project and all tests passed: `6 passed, 1 warning`.
- Tests cover create→get, list with `limit`/`offset`, `q` text search, bbox filtering, and `PATCH` update (all assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e6ad453d48326a64a09a4427c6795)