### PR TITLE
docs: expand README for MVP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
+#### 依存関係を追加するとき（MVP拡張時）
+- **requirements.txt 管理の場合**：追加したいパッケージ名を `requirements.txt` に追記してから再インストール。
+- **pyproject.toml 管理の場合**：`[project] dependencies = [...]` に追記して `pip install -e .` を再実行。
+```powershell
+# 例：requirements.txt を更新した場合
+pip install -r requirements.txt
+```
+
 ### 4) 起動（API）
 ```powershell
 uvicorn tatemono_map.api.main:app --reload --host 127.0.0.1 --port 8000
@@ -58,12 +66,35 @@ Invoke-RestMethod http://127.0.0.1:8000/health
 - http://127.0.0.1:8000/
 - http://127.0.0.1:8000/b/demo
 
+#### /buildings の作成・取得（PowerShell 例）
+```powershell
+# 作成（POST）
+$body = @{
+  name = "サンプルビル"
+  address = "東京都千代田区1-1-1"
+  lat = 35.681236
+  lng = 139.767125
+  building_type = "office"
+  floors = 10
+  year_built = 1999
+  source = "manual"
+} | ConvertTo-Json
+
+Invoke-RestMethod -Method Post -Uri http://127.0.0.1:8000/buildings `
+  -ContentType "application/json" -Body $body
+
+# 取得（GET）
+Invoke-RestMethod http://127.0.0.1:8000/buildings
+```
+
 ---
 
 ## .env / secrets の扱い（重要）
 - **secrets/.env はコミットしない**でください。
 - 推奨：`.env.example` を作り、**安全な値だけ**をサンプルとして共有します。
 - 実運用の `.env` は **ローカルだけ**に保存してください。
+- **SQLITE_DB_PATH**：SQLite のファイルパスを指定（未指定なら `./data/tatemono_map.sqlite3`）。
+- **.env.example**：`DATABASE_URL` などの接続先や通知系のキーを記載した雛形です。実運用値は `.env` にのみ保存します。
 
 ---
 


### PR DESCRIPTION
### Motivation
- Preserve the existing Windows + PowerShell single-command workflow while adding minimal notes required for the MVP extension so new users can start the app, hit `/health`, create a `/buildings` entry and retrieve it using only the README.
- Clarify how to add new Python dependencies depending on whether the project uses `requirements.txt` or `pyproject.toml` so maintainers can update and reinstall easily.
- Explain the `SQLITE_DB_PATH` environment variable and the purpose of `.env.example` so DB location and secrets handling are explicit.

### Description
- Updated `README.md` to add guidance for adding dependencies when managed by `requirements.txt` or by `pyproject.toml` and example reinstall commands such as `pip install -r requirements.txt` and `pip install -e .`.
- Added PowerShell examples demonstrating how to create a building (`POST /buildings`) and fetch buildings (`GET /buildings`) using `Invoke-RestMethod` for quick MVP verification.
- Documented `SQLITE_DB_PATH` default path (`./data/tatemono_map.sqlite3`) and clarified that `.env.example` is a template for `DATABASE_URL` and notification keys while production secrets should remain in `.env`.
- Kept all existing startup and one-shot instructions (e.g. `uvicorn tatemono_map.api.main:app --reload --host 127.0.0.1 --port 8000`) intact without removal or replacement.

### Testing
- No automated tests were executed because this is a documentation-only change.
- The changes are limited to `README.md` and do not modify runtime code or test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e6d6013c083268caae6d77f08e2fb)