### PR TITLE
docs: make single-path workflow unmistakable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.pyc
 .env
 data/
+db/
 *.sqlite3
 data/*.db
 data/*.sqlite3

--- a/README.md
+++ b/README.md
@@ -4,27 +4,23 @@
 
 ---
 
-## 最短ルート（迷ったらこれ）
+## 最短ルート（迷ったらここだけ）
 **1本の流れで迷わない運用手順です。GitHub で merge した後の同期もこれだけ。**
 
-1) **ローカル同期（GitHubの変更をローカルへ）**
-```powershell
-pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\tatemono-map\scripts\sync.ps1"
-```
+0) **前提：PowerShell 7.x / Windows 11**
+
+1) **ローカル同期（GitHub→ローカル）**
+**`pwsh -NoProfile -ExecutionPolicy Bypass -Command "cd $env:USERPROFILE\tatemono-map; git pull --ff-only; git status"`**
 
 2) **起動（API起動）**
-```powershell
-pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\tatemono-map\scripts\dev.ps1"
-```
+**`pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\tatemono-map\scripts\dev.ps1"`**
 
-3) **コミット＆push（変更をGitHubへ）**
-```powershell
-pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\tatemono-map\scripts\push.ps1" -Message "ここにコミットメッセージ"
-```
+3) **変更の取り込み（コミット&push）**
+**`pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\tatemono-map\scripts\push.ps1" -Message "ここにコミットメッセージ"`**
 
-### よくあるミス（短く）
-- `git status` などの **出力を貼り付けて実行しない**（出力はコマンドではありません）
-- **repo外で `git` を直接叩かない**（同期・push は scripts に一本化）
+4) **よくある停止理由（sync.ps1が止まる）**
+- “Untracked files: db/ があると sync.ps1 が止まる”
+  - **対処（1行）**：`db/` を `.gitignore` に入れる（推奨） or `sync.ps1 -Force`
 
 ---
 


### PR DESCRIPTION
### Motivation
- Provide a single, unambiguous workflow for everyday work so users always follow the same steps: sync → start → commit & push. 
- Ensure commands can be run from anywhere and remove ambiguity about where to run `git` or the scripts. 
- Surface the minimal safe `git pull` one-liner to prevent mistaken manual `git` usage. 
- Prevent `sync.ps1` from stopping due to locally generated DB files by documenting the condition and ignoring the files.

### Description
- Rewrote `README.md` to center on a short "最短ルート（迷ったらここだけ）」 flow and made the one-shot commands explicit and runnable from any location using `$env:USERPROFILE\tatemono-map`.
- Promoted a single safe sync command: `pwsh -NoProfile -ExecutionPolicy Bypass -Command "cd $env:USERPROFILE\tatemono-map; git pull --ff-only; git status"` as the top-line step. 
- Unified launch and push commands to the anywhere-run form: `pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\tatemono-map\scripts\dev.ps1"` and `pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\tatemono-map\scripts\push.ps1" -Message "..."`.
- Added a concise FAQ entry explaining that `sync.ps1` can stop when `Untracked files: db/` exists and recommended either adding `db/` to `.gitignore` or using `sync.ps1 -Force`, and added `db/` to `.gitignore`.

### Testing
- No automated tests were executed as part of this documentation and .gitignore change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e8c5dfb808326a3d671b394d9aece)