### PR TITLE
Make README quickstart commands copy-friendly (multi-line PowerShell blocks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,29 @@
 
 0) **前提：PowerShell 7.x / Windows 11**
 
-1) **ローカル同期（GitHub→ローカル）**
-**`pwsh -NoProfile -ExecutionPolicy Bypass -Command "cd $env:USERPROFILE\tatemono-map; git pull --ff-only; git status"`**
+1) **同期（GitHub→ローカル）**
+```powershell
+$REPO = Join-Path $env:USERPROFILE "tatemono-map"
+Set-Location $REPO
+git pull --ff-only
+git status
+```
 
-2) **起動（API起動）**
-**`pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\tatemono-map\scripts\dev.ps1"`**
+2) **起動（scripts/dev.ps1）**
+```powershell
+$REPO = Join-Path $env:USERPROFILE "tatemono-map"
+pwsh -NoProfile -ExecutionPolicy Bypass -File "$REPO\scripts\dev.ps1"
+```
 
-3) **変更の取り込み（コミット&push）**
-**`pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\tatemono-map\scripts\push.ps1" -Message "ここにコミットメッセージ"`**
+3) **疎通（別ターミナルで）**
+```powershell
+Invoke-RestMethod "http://127.0.0.1:8000/health"
+```
 
-4) **よくある停止理由（sync.ps1が止まる）**
+4) **変更の取り込み（コミット&push）**
+- `scripts/push.ps1` で一発 push（詳細は下記の「スクリプト一覧」）
+
+5) **よくある停止理由（sync.ps1が止まる）**
 - “Untracked files: db/ があると sync.ps1 が止まる”
   - **対処（1行）**：`db/` を `.gitignore` に入れる（推奨） or `sync.ps1 -Force`
 


### PR DESCRIPTION
### Motivation
- Make the "最短ルート" quickstart easier to copy via GitHub's copy button by avoiding long one-liners that require horizontal scrolling.
- Shorten line length using a shared `$REPO = Join-Path $env:USERPROFILE "tatemono-map"` to improve readability and prevent the copy button from being obscured.
- Ensure the displayed commands are valid executable PowerShell snippets using `Set-Location`, `git pull --ff-only`, and `Invoke-RestMethod`.

### Description
- Replace the single long one-line sync/start/push commands with three independent fenced `powershell` code blocks for sync, start, and health check, each initializing `$REPO`.
- The sync block runs `Set-Location`, `git pull --ff-only`, and `git status`; the start block invokes `pwsh -NoProfile -ExecutionPolicy Bypass -File "$REPO\scripts\dev.ps1"`; the health block runs `Invoke-RestMethod "http://127.0.0.1:8000/health"`.
- Preserve guidance about `scripts/push.ps1` and keep the existing "スクリプト一覧" and other README explanations intact.

### Testing
- No automated tests were run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e8fe916d08326b77fbe35c9fd7824)