### PR TITLE
Fix Mansion Review list-facts: merge split facts and authoritative access/floor updates

### DIFF
--- a/scripts/mansion_review_crawl_to_csv.py
+++ b/scripts/mansion_review_crawl_to_csv.py
@@ -1320,6 +1320,46 @@ def parse_detail_facts(html: str, detail_url: str, fallback_name: str, fallback_
     )
 
 
+
+
+def _merge_facts_row(base: FactsRow, incoming: FactsRow) -> FactsRow:
+    merged = FactsRow(**asdict(base))
+
+    def _pick_text(current: str, candidate: str) -> str:
+        return current if normalize_space(current) else normalize_space(candidate)
+
+    merged.building_name = _pick_text(merged.building_name, incoming.building_name)
+    merged.address = _pick_text(merged.address, incoming.address)
+    merged.structure = _pick_text(merged.structure, incoming.structure)
+    merged.access_info = _pick_text(merged.access_info, incoming.access_info)
+    merged.floor_count_text = _pick_text(merged.floor_count_text, incoming.floor_count_text)
+    merged.management_style = _pick_text(merged.management_style, incoming.management_style)
+    merged.built_year_month = _pick_text(merged.built_year_month, incoming.built_year_month)
+    merged.property_kind = _pick_text(merged.property_kind, incoming.property_kind)
+    merged.sale_layout_types_json = _pick_text(merged.sale_layout_types_json, incoming.sale_layout_types_json)
+    merged.availability_label = _pick_text(merged.availability_label, incoming.availability_label)
+    merged.evidence_id = _pick_text(merged.evidence_id, incoming.evidence_id)
+    merged.raw_block = _pick_text(merged.raw_block, incoming.raw_block)
+
+    merged.total_units = merged.total_units if merged.total_units is not None else incoming.total_units
+    merged.sale_price_yen_min = merged.sale_price_yen_min if merged.sale_price_yen_min is not None else incoming.sale_price_yen_min
+    merged.sale_price_yen_max = merged.sale_price_yen_max if merged.sale_price_yen_max is not None else incoming.sale_price_yen_max
+    merged.sale_price_yen_avg = merged.sale_price_yen_avg if merged.sale_price_yen_avg is not None else incoming.sale_price_yen_avg
+    merged.sale_area_sqm_min = merged.sale_area_sqm_min if merged.sale_area_sqm_min is not None else incoming.sale_area_sqm_min
+    merged.sale_area_sqm_max = merged.sale_area_sqm_max if merged.sale_area_sqm_max is not None else incoming.sale_area_sqm_max
+    merged.sale_listing_count = merged.sale_listing_count if merged.sale_listing_count is not None else incoming.sale_listing_count
+    merged.avg_rent_yen = merged.avg_rent_yen if merged.avg_rent_yen is not None else incoming.avg_rent_yen
+    merged.rental_listing_count = merged.rental_listing_count if merged.rental_listing_count is not None else incoming.rental_listing_count
+    return merged
+
+
+def _facts_merge_key(fact: FactsRow) -> str:
+    property_kind = normalize_space(fact.property_kind)
+    address = normalize_space(fact.address)
+    if address:
+        return f"{property_kind}|addr|{address}"
+    return f"{property_kind}|name|{normalize_space(fact.building_name)}"
+
 def write_facts_csv(rows: list[FactsRow], out_csv: Path) -> None:
     out_csv.parent.mkdir(parents=True, exist_ok=True)
     with out_csv.open("w", encoding="utf-8-sig", newline="") as fp:
@@ -1596,10 +1636,9 @@ def run_crawl(
     if mode == "facts":
         facts_map: dict[str, FactsRow] = {}
         for fact in all_facts_rows:
-            key = f"{fact.property_kind}|{normalize_space(fact.building_name)}|{normalize_space(fact.address)}"
-            if key in facts_map:
-                continue
-            facts_map[key] = fact
+            key = _facts_merge_key(fact)
+            existing = facts_map.get(key)
+            facts_map[key] = _merge_facts_row(existing, fact) if existing else fact
 
         if not facts_map:
             for row in all_rows:

--- a/src/tatemono_map/building_registry/ingest_building_facts.py
+++ b/src/tatemono_map/building_registry/ingest_building_facts.py
@@ -131,6 +131,15 @@ def _is_valid_floor_count_text(value: str | None) -> bool:
     return False
 
 
+def _normalize_authoritative_mansion_review_value(value: str | None, *, field: str) -> str:
+    cleaned = _clean_text(value)
+    if field == "access_info":
+        return "" if _is_invalid_access_info(cleaned) else cleaned
+    if field == "floor_count_text":
+        return cleaned if _is_valid_floor_count_text(cleaned) else ""
+    return cleaned
+
+
 def _should_repair_field(existing_value: str | None, new_value: str | None, *, field: str) -> bool:
     existing = _clean_text(existing_value)
     new = _clean_text(new_value)
@@ -430,21 +439,28 @@ def ingest_building_facts_csv(
             is_bunjo = property_kind == "bunjo"
             should_repair_access_info = False
             should_repair_floor_count = False
+            should_overwrite_access_info = False
+            should_overwrite_floor_count = False
+            should_clear_stale_access_info = False
+            should_clear_stale_floor_count = False
             if merge == "fill_only" and source == "mansion_review_list_facts":
                 existing_building = conn.execute(
                     "SELECT access_info, floor_count_text FROM buildings WHERE building_id=?",
                     (building_id,),
                 ).fetchone()
-                should_repair_access_info = _should_repair_field(
-                    existing_building["access_info"] if existing_building else None,
-                    access_info,
-                    field="access_info",
-                )
-                should_repair_floor_count = _should_repair_field(
-                    existing_building["floor_count_text"] if existing_building else None,
-                    floor_count_text,
-                    field="floor_count_text",
-                )
+                existing_access = existing_building["access_info"] if existing_building else None
+                existing_floor = existing_building["floor_count_text"] if existing_building else None
+
+                access_info = _normalize_authoritative_mansion_review_value(access_info, field="access_info")
+                floor_count_text = _normalize_authoritative_mansion_review_value(floor_count_text, field="floor_count_text")
+
+                should_repair_access_info = _should_repair_field(existing_access, access_info, field="access_info")
+                should_repair_floor_count = _should_repair_field(existing_floor, floor_count_text, field="floor_count_text")
+
+                should_overwrite_access_info = bool(access_info)
+                should_overwrite_floor_count = bool(floor_count_text)
+                should_clear_stale_access_info = (not access_info) and _is_invalid_access_info(existing_access)
+                should_clear_stale_floor_count = (not floor_count_text) and (not _is_valid_floor_count_text(existing_floor))
 
             if merge == "overwrite" and not is_mansion_review:
                 conn.execute(
@@ -504,10 +520,14 @@ def ingest_building_facts_csv(
                             built_year_month={_fill_only_sql('built_year_month')},
                             property_kind={_fill_only_sql('property_kind')},
                             access_info=CASE
+                                WHEN ? THEN NULL
+                                WHEN ? THEN ?
                                 WHEN access_info IS NULL OR access_info = '' OR ? THEN ?
                                 ELSE access_info
                             END,
                             floor_count_text=CASE
+                                WHEN ? THEN NULL
+                                WHEN ? THEN ?
                                 WHEN floor_count_text IS NULL OR floor_count_text = '' OR ? THEN ?
                                 ELSE floor_count_text
                             END,
@@ -525,8 +545,14 @@ def ingest_building_facts_csv(
                             age_years,
                             built_year_month,
                             property_kind,
+                            should_clear_stale_access_info,
+                            should_overwrite_access_info,
+                            access_info,
                             should_repair_access_info,
                             access_info,
+                            should_clear_stale_floor_count,
+                            should_overwrite_floor_count,
+                            floor_count_text,
                             should_repair_floor_count,
                             floor_count_text,
                             total_units,
@@ -559,10 +585,14 @@ def ingest_building_facts_csv(
                             avg_rent_yen=CASE WHEN avg_rent_yen IS NULL THEN ? ELSE avg_rent_yen END,
                             rental_listing_count=CASE WHEN rental_listing_count IS NULL THEN ? ELSE rental_listing_count END,
                             access_info=CASE
+                                WHEN ? THEN NULL
+                                WHEN ? THEN ?
                                 WHEN access_info IS NULL OR access_info = '' OR ? THEN ?
                                 ELSE access_info
                             END,
                             floor_count_text=CASE
+                                WHEN ? THEN NULL
+                                WHEN ? THEN ?
                                 WHEN floor_count_text IS NULL OR floor_count_text = '' OR ? THEN ?
                                 ELSE floor_count_text
                             END,
@@ -579,8 +609,14 @@ def ingest_building_facts_csv(
                             sale_listing_count,
                             avg_rent_yen,
                             rental_listing_count,
+                            should_clear_stale_access_info,
+                            should_overwrite_access_info,
+                            access_info,
                             should_repair_access_info,
                             access_info,
+                            should_clear_stale_floor_count,
+                            should_overwrite_floor_count,
+                            floor_count_text,
                             should_repair_floor_count,
                             floor_count_text,
                             total_units,

--- a/tests/test_ingest_building_facts.py
+++ b/tests/test_ingest_building_facts.py
@@ -295,7 +295,7 @@ def test_ingest_building_facts_repairs_invalid_floor_count_text_for_mansion_revi
     assert row["floor_count_text"] == "地上11階建"
 
 
-def test_ingest_building_facts_keeps_valid_existing_access_info_for_mansion_review_list_facts(tmp_path: Path) -> None:
+def test_ingest_building_facts_mansion_review_list_prefers_source_access_info_even_if_existing_valid(tmp_path: Path) -> None:
     db = tmp_path / "facts7.sqlite3"
     conn = connect(db)
     conn.execute(
@@ -326,4 +326,76 @@ def test_ingest_building_facts_keeps_valid_existing_access_info_for_mansion_revi
     conn = connect(db)
     row = conn.execute("SELECT access_info FROM buildings WHERE building_id='b7'").fetchone()
     conn.close()
-    assert row["access_info"] == "JR日豊本線(門司港～佐伯) 南小倉駅 徒歩 32 分"
+    assert row["access_info"] == "南小倉駅 徒歩 32 分"
+
+
+def test_ingest_building_facts_mansion_review_list_overwrites_existing_access_and_floor(tmp_path: Path) -> None:
+    db = tmp_path / "facts8.sqlite3"
+    conn = connect(db)
+    conn.execute(
+        """
+        INSERT INTO buildings(building_id, canonical_name, canonical_address, norm_name, norm_address, access_info, floor_count_text)
+        VALUES ('b8','Gマンション','福岡県北九州市小倉北区浅野2-2-2','gまんしょん','北九州市小倉北区浅野2-2-2',
+        'JR日豊本線(門司港～佐伯) 城野駅 徒歩 12 分', '地上7階建')
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    csv_path = tmp_path / "facts8.csv"
+    _write_facts_csv(
+        csv_path,
+        [
+            {
+                "building_name": "Gマンション",
+                "address": "福岡県北九州市小倉北区浅野2-2-2",
+                "access_info": "北九州モノレール 旦過駅 徒歩 9 分",
+                "floor_count_text": "地上15階建",
+                "evidence_id": "mr:8",
+            }
+        ],
+    )
+
+    ingest_building_facts_csv(str(db), str(csv_path), source="mansion_review_list_facts", merge="fill_only")
+
+    conn = connect(db)
+    row = conn.execute("SELECT access_info, floor_count_text FROM buildings WHERE building_id='b8'").fetchone()
+    conn.close()
+    assert row["access_info"] == "北九州モノレール 旦過駅 徒歩 9 分"
+    assert row["floor_count_text"] == "地上15階建"
+
+
+def test_ingest_building_facts_mansion_review_list_clears_stale_invalid_when_source_empty(tmp_path: Path) -> None:
+    db = tmp_path / "facts9.sqlite3"
+    conn = connect(db)
+    conn.execute(
+        """
+        INSERT INTO buildings(building_id, canonical_name, canonical_address, norm_name, norm_address, access_info, floor_count_text)
+        VALUES ('b9','Hマンション','福岡県北九州市門司区社ノ木1-1-1','hまんしょん','北九州市門司区社ノ木1-1-1',
+        '築年数 2007年2月 口コミ数 2 平均賃料 44', 'て')
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    csv_path = tmp_path / "facts9.csv"
+    _write_facts_csv(
+        csv_path,
+        [
+            {
+                "building_name": "Hマンション",
+                "address": "福岡県北九州市門司区社ノ木1-1-1",
+                "access_info": "",
+                "floor_count_text": "",
+                "evidence_id": "mr:9",
+            }
+        ],
+    )
+
+    ingest_building_facts_csv(str(db), str(csv_path), source="mansion_review_list_facts", merge="fill_only")
+
+    conn = connect(db)
+    row = conn.execute("SELECT access_info, floor_count_text FROM buildings WHERE building_id='b9'").fetchone()
+    conn.close()
+    assert row["access_info"] in {None, ""}
+    assert row["floor_count_text"] in {None, ""}

--- a/tests/test_mansion_review_crawl_to_csv.py
+++ b/tests/test_mansion_review_crawl_to_csv.py
@@ -1096,3 +1096,60 @@ def test_run_crawl_facts_replaces_invalid_non_empty_address_with_detail_ward_onl
     csv_text = facts_csv.read_text(encoding="utf-8-sig")
     assert "市区町村もしくは駅を1つ以上選択してください" not in csv_text
     assert "北九州市門司区下二十町" in csv_text
+
+
+def test_merge_facts_row_uses_address_key_and_complements_fields() -> None:
+    left = crawl.FactsRow(
+        building_name="ドミール小倉",
+        address="北九州市小倉北区紺屋町1-2-3",
+        structure="",
+        access_info="",
+        floor_count_text="地上11階建",
+        total_units=None,
+        management_style="",
+        built_year_month="",
+        property_kind="chintai",
+        sale_price_yen_min=None,
+        sale_price_yen_max=None,
+        sale_price_yen_avg=None,
+        sale_area_sqm_min=None,
+        sale_area_sqm_max=None,
+        sale_layout_types_json="",
+        sale_listing_count=None,
+        avg_rent_yen=None,
+        rental_listing_count=None,
+        availability_label="",
+        evidence_id="mr:left",
+        raw_block="階建て: 地上11階建",
+    )
+    right = crawl.FactsRow(
+        building_name="レオパレスドミール小倉",
+        address="北九州市小倉北区紺屋町1-2-3",
+        structure="",
+        access_info="JR日豊本線(門司港～佐伯) 南小倉駅 徒歩 32 分",
+        floor_count_text="",
+        total_units=None,
+        management_style="",
+        built_year_month="",
+        property_kind="chintai",
+        sale_price_yen_min=None,
+        sale_price_yen_max=None,
+        sale_price_yen_avg=None,
+        sale_area_sqm_min=None,
+        sale_area_sqm_max=None,
+        sale_layout_types_json="",
+        sale_listing_count=None,
+        avg_rent_yen=None,
+        rental_listing_count=None,
+        availability_label="",
+        evidence_id="mr:right",
+        raw_block="交通: JR日豊本線(門司港～佐伯) 南小倉駅 徒歩 32 分",
+    )
+
+    key_left = crawl._facts_merge_key(left)
+    key_right = crawl._facts_merge_key(right)
+    assert key_left == key_right
+
+    merged = crawl._merge_facts_row(left, right)
+    assert merged.access_info == "JR日豊本線(門司港～佐伯) 南小倉駅 徒歩 32 分"
+    assert merged.floor_count_text == "地上11階建"


### PR DESCRIPTION
### Motivation
- The Mansion Review list-derived pipeline produced split/fragmented building facts (交通 / 階建て) and allowed stale or noisy DB values to persist, breaking URL → CSV → DB → summary → render/front consistency. 
- The intent is to fix these issues with minimal, general rules that apply to all buildings (no per-building hardcodes) and to avoid fabricating values when the source is empty. 

### Description
- Consolidate facts rows during crawl by adding `_facts_merge_key` and `_merge_facts_row` in `scripts/mansion_review_crawl_to_csv.py` so rows with the same property kind + address are merged and complementary fields (交通, 階建て, raw_block, etc.) are coalesced. 
- Treat `mansion_review_list_facts` as authoritative for `access_info` and `floor_count_text` in `src/tatemono_map/building_registry/ingest_building_facts.py` by adding `_normalize_authoritative_mansion_review_value`, normalizing incoming values, overwriting when the source value is valid, and clearing stale/invalid DB values when the source is truly empty. 
- Update the SQL update logic to allow clearing stale fields and to apply the new overwrite/repair conditions only for the list-facts source, keeping other merge modes unchanged. 
- Add and extend unit tests to cover the facts-merge behavior and the authoritative overwrite/cleanup semantics in `tests/test_mansion_review_crawl_to_csv.py` and `tests/test_ingest_building_facts.py`, without touching templates, public DB files, or frontend assets. 

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mansion_review_crawl_to_csv.py tests/test_ingest_building_facts.py` which completed with all tests passing (`44 passed`).
- Ran `PYTHONPATH=. pytest -q tests/test_mansion_review_list_to_master_import.py tests/test_building_matcher_variants.py` which completed with all tests passing (`13 passed`).
- The added tests exercise merging split facts rows and the new ingest behavior for overwriting and clearing `access_info` / `floor_count_text`, and they passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6d9df8b988326a8567359d49d056c)