### PR TITLE
Rebuild Mansion Review crawl/list pipeline with minimal DOM contract

### DIFF
--- a/scripts/mansion_review_crawl_to_csv.py
+++ b/scripts/mansion_review_crawl_to_csv.py
@@ -9,7 +9,6 @@ import time
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable
 from urllib.parse import urljoin
 
 import requests
@@ -63,6 +62,9 @@ FACTS_COLUMNS = (
     "raw_block",
 )
 
+CHINTAI_ORDER = ["賃料", "管理費", "敷金", "礼金", "専有面積", "間取り"]
+MANSION_ORDER = ["価格", "坪単価", "専有面積", "間取り", "所在階", "向き"]
+
 
 @dataclass
 class ListRow:
@@ -89,12 +91,6 @@ class ListRow:
     direction_text: str
 
 
-@dataclass
-class ParseDebug:
-    selector_hits: dict[str, int]
-    selector_trace: list[str]
-
-
 def normalize_space(text: str | None) -> str:
     return re.sub(r"\s+", " ", text or "").strip()
 
@@ -119,25 +115,25 @@ def parse_max_page(html: str, *, kind: str, city_id: str) -> int:
     for node in tree.css("a[href]"):
         href = normalize_space(node.attributes.get("href"))
         m = pattern.search(href)
-        if not m:
-            continue
-        page = int(m.group(1) or "1")
-        max_page = max(max_page, page)
+        if m:
+            max_page = max(max_page, int(m.group(1) or "1"))
     return max_page
 
 
-def _extract_building_facts(card: Node) -> dict[str, str]:
+def _extract_facts_map(card: Node) -> dict[str, str]:
     root = card.css_first(".property-detail-content_main")
     if root is None:
         return {}
 
     facts: dict[str, str] = {}
     for dl in root.css("dl"):
-        for dt, dd in zip(dl.css("dt"), dl.css("dd")):
+        dts = dl.css("dt")
+        dds = dl.css("dd")
+        for dt, dd in zip(dts, dds):
             key = normalize_space(dt.text(separator=" ")).replace("：", "").replace(":", "")
-            value = normalize_space(dd.text(separator=" "))
-            if key and value:
-                facts[key] = value
+            val = normalize_space(dd.text(separator=" "))
+            if key and val:
+                facts[key] = val
 
     for row in root.css("tr"):
         th = row.css_first("th")
@@ -145,13 +141,14 @@ def _extract_building_facts(card: Node) -> dict[str, str]:
         if not th or not td:
             continue
         key = normalize_space(th.text(separator=" ")).replace("：", "").replace(":", "")
-        value = normalize_space(td.text(separator=" "))
-        if key and value:
-            facts[key] = value
+        val = normalize_space(td.text(separator=" "))
+        if key and val:
+            facts[key] = val
+
     return facts
 
 
-def _building_fact_value(facts: dict[str, str], labels: Iterable[str]) -> str:
+def _fact(facts: dict[str, str], *labels: str) -> str:
     for label in labels:
         value = normalize_space(facts.get(label))
         if value:
@@ -168,157 +165,120 @@ def _extract_detail_url(card: Node, page_url: str, kind: str) -> str:
     return ""
 
 
-def _headers_for_table(table: Node) -> list[str]:
-    head_cells = table.css("thead th")
-    if not head_cells:
-        head_cells = table.css("tr.recommend_head th, tr.recommendHead th")
-    if not head_cells:
-        return []
-    return [normalize_space(cell.text(separator=" ")).replace(" ", "") for cell in head_cells]
+def _table_headers(table: Node) -> list[str]:
+    ths = table.css("thead th") or table.css("tr.recommend_head th, tr.recommendHead th")
+    return [normalize_space(th.text(separator=" ")).replace(" ", "") for th in ths]
 
 
-def _split_rent_and_fee(value: str) -> tuple[str, str]:
-    text = normalize_space(value)
-    if not text:
-        return "", ""
-    m = re.match(r"^(.*?)\((.*?)\)$", text)
-    if m:
-        return normalize_space(m.group(1)), normalize_space(m.group(2))
-    if "/" in text:
-        left, right = text.split("/", 1)
-        return normalize_space(left), normalize_space(right)
-    return text, ""
-
-
-def _value_from_columns(columns: dict[str, str], *keys: str) -> str:
-    for key in keys:
-        if key in columns:
-            return columns[key]
-    return ""
-
-
-def _columns_from_row(tr: Node, headers: list[str], *, kind: str) -> dict[str, str]:
+def _row_columns(tr: Node, headers: list[str], order: list[str]) -> dict[str, str]:
     cells = [normalize_space(td.text(separator=" ")) for td in tr.css("td")]
     if not cells:
         return {}
 
     if headers:
-        return {headers[idx]: cells[idx] for idx in range(min(len(headers), len(cells)))}
+        return {headers[i]: cells[i] for i in range(min(len(headers), len(cells)))}
 
-    inferred: dict[str, str] = {}
-    td_nodes = tr.css("td")
-    for idx, td in enumerate(td_nodes):
-        label = normalize_space(
+    labeled: dict[str, str] = {}
+    for i, td in enumerate(tr.css("td")):
+        key = normalize_space(
             td.attributes.get("data-th")
             or td.attributes.get("data-title")
             or td.attributes.get("data-label")
         ).replace(" ", "")
-        if label:
-            inferred[label] = cells[idx]
-    if inferred:
-        return inferred
+        if key:
+            labeled[key] = cells[i]
+    if labeled:
+        return labeled
 
-    if kind == "chintai":
-        ordered_keys = ["賃料", "管理費", "敷金", "礼金", "専有面積", "間取り"]
-    else:
-        ordered_keys = ["価格", "坪単価", "専有面積", "間取り", "所在階", "向き"]
-    return {ordered_keys[idx]: cells[idx] for idx in range(min(len(ordered_keys), len(cells)))}
+    return {order[i]: cells[i] for i in range(min(len(order), len(cells)))}
 
 
-def parse_list_page(html: str, page_url: str, kind: str, city_id: str, page_no: int) -> tuple[list[ListRow], ParseDebug]:
+def parse_list_page(html: str, page_url: str, kind: str, city_id: str, page_no: int) -> tuple[list[ListRow], dict[str, int]]:
     tree = HTMLParser(html)
     cards = tree.css("li.property-detail-list-item, section.property-detail-list-item, article.property-detail-list-item")
-    selector_trace = ["li/section/article.property-detail-list-item"]
-
     rows: list[ListRow] = []
+
     for card in cards:
-        facts = _extract_building_facts(card)
-        building_name = normalize_space(
-            (card.css_first("h1, h2, h3, .property-name, .mansionName") or card).text(separator=" ")
-        )
-        address = _building_fact_value(facts, ("住所", "所在地"))
-        access_text = _building_fact_value(facts, ("交通", "アクセス"))
-        built_text = _building_fact_value(facts, ("築年数", "築年月", "築"))
-        building_floor_count_text = _building_fact_value(facts, ("階建て", "建物階数"))
-        total_units_text = _building_fact_value(facts, ("総戸数",))
+        facts = _extract_facts_map(card)
+        name_node = card.css_first("h1, h2, h3, .property-name, .mansionName")
+        building_name = normalize_space(name_node.text(separator=" ") if name_node else "")
         detail_url = _extract_detail_url(card, page_url, kind)
 
-        recommend_table = card.css_first("table.recommendTable")
-        if recommend_table is None:
+        table = card.css_first("table.recommendTable")
+        if table is None:
             continue
 
-        headers = _headers_for_table(recommend_table)
-        recommend_rows = recommend_table.css("tbody.recommend_row tr")
-        for tr in recommend_rows:
-            columns = _columns_from_row(tr, headers, kind=kind)
-            if not columns:
+        headers = _table_headers(table)
+        row_nodes = table.css("tbody.recommend_row tr")
+        for tr in row_nodes:
+            cols = _row_columns(tr, headers, CHINTAI_ORDER if kind == "chintai" else MANSION_ORDER)
+            if not cols:
                 continue
 
             if kind == "chintai":
-                rent_or_combined = _value_from_columns(columns, "賃料", "賃料(管理費)", "賃料/管理費")
-                rent_text, fee_inline = _split_rent_and_fee(rent_or_combined)
-                fee_text = _value_from_columns(columns, "管理費", "共益費") or fee_inline
-                row = ListRow(
-                    kind=kind,
-                    city_id=city_id,
-                    ward=CITY_MAP.get(city_id, ""),
-                    city_page=f"{city_id}_{page_no}",
-                    page_url=page_url,
-                    detail_url=detail_url,
-                    building_name=building_name,
-                    address=address,
-                    access_text=access_text,
-                    built_text=built_text,
-                    building_floor_count_text=building_floor_count_text,
-                    total_units_text=total_units_text,
-                    price_or_rent_text=rent_text,
-                    fee_text=fee_text,
-                    tsubo_unit_price_text="",
-                    deposit_text=_value_from_columns(columns, "敷金"),
-                    key_money_text=_value_from_columns(columns, "礼金"),
-                    area_text=_value_from_columns(columns, "専有面積", "面積"),
-                    layout_text=_value_from_columns(columns, "間取り"),
-                    floor_text="",
-                    direction_text="",
+                rows.append(
+                    ListRow(
+                        kind=kind,
+                        city_id=city_id,
+                        ward=CITY_MAP.get(city_id, ""),
+                        city_page=f"{city_id}_{page_no}",
+                        page_url=page_url,
+                        detail_url=detail_url,
+                        building_name=building_name,
+                        address=_fact(facts, "住所", "所在地"),
+                        access_text=_fact(facts, "交通", "アクセス"),
+                        built_text=_fact(facts, "築年数", "築年月", "築"),
+                        building_floor_count_text=_fact(facts, "階建て", "建物階数"),
+                        total_units_text=_fact(facts, "総戸数"),
+                        price_or_rent_text=cols.get("賃料", cols.get("賃料(管理費)", "")),
+                        fee_text=cols.get("管理費", cols.get("共益費", "")),
+                        tsubo_unit_price_text="",
+                        deposit_text=cols.get("敷金", ""),
+                        key_money_text=cols.get("礼金", ""),
+                        area_text=cols.get("専有面積", cols.get("面積", "")),
+                        layout_text=cols.get("間取り", ""),
+                        floor_text="",
+                        direction_text="",
+                    )
                 )
             else:
-                row = ListRow(
-                    kind=kind,
-                    city_id=city_id,
-                    ward=CITY_MAP.get(city_id, ""),
-                    city_page=f"{city_id}_{page_no}",
-                    page_url=page_url,
-                    detail_url=detail_url,
-                    building_name=building_name,
-                    address=address,
-                    access_text=access_text,
-                    built_text=built_text,
-                    building_floor_count_text=building_floor_count_text,
-                    total_units_text=total_units_text,
-                    price_or_rent_text=_value_from_columns(columns, "価格", "販売価格"),
-                    fee_text="",
-                    tsubo_unit_price_text=_value_from_columns(columns, "坪単価"),
-                    deposit_text="",
-                    key_money_text="",
-                    area_text=_value_from_columns(columns, "専有面積", "面積"),
-                    layout_text=_value_from_columns(columns, "間取り"),
-                    floor_text=_value_from_columns(columns, "所在階", "階"),
-                    direction_text=_value_from_columns(columns, "向き", "主要採光面"),
+                rows.append(
+                    ListRow(
+                        kind=kind,
+                        city_id=city_id,
+                        ward=CITY_MAP.get(city_id, ""),
+                        city_page=f"{city_id}_{page_no}",
+                        page_url=page_url,
+                        detail_url=detail_url,
+                        building_name=building_name,
+                        address=_fact(facts, "住所", "所在地"),
+                        access_text=_fact(facts, "交通", "アクセス"),
+                        built_text=_fact(facts, "築年数", "築年月", "築"),
+                        building_floor_count_text=_fact(facts, "階建て", "建物階数"),
+                        total_units_text=_fact(facts, "総戸数"),
+                        price_or_rent_text=cols.get("価格", cols.get("販売価格", "")),
+                        fee_text="",
+                        tsubo_unit_price_text=cols.get("坪単価", ""),
+                        deposit_text="",
+                        key_money_text="",
+                        area_text=cols.get("専有面積", cols.get("面積", "")),
+                        layout_text=cols.get("間取り", ""),
+                        floor_text=cols.get("所在階", cols.get("階", "")),
+                        direction_text=cols.get("向き", cols.get("主要採光面", "")),
+                    )
                 )
-            rows.append(row)
 
-    return rows, ParseDebug(selector_hits={"cards": len(cards), "rows": len(rows)}, selector_trace=selector_trace)
+    return rows, {"cards": len(cards), "rows": len(rows)}
 
 
 def _cache_path(cache_dir: Path, url: str) -> Path:
-    key = hashlib.sha1(url.encode("utf-8")).hexdigest()
-    return cache_dir / f"{key}.html"
+    return cache_dir / f"{hashlib.sha1(url.encode('utf-8')).hexdigest()}.html"
 
 
-def fetch_html(session: requests.Session, url: str, cache_dir: Path, *, retry_count: int, sleep_sec: float) -> tuple[str, bool]:
-    cache_file = _cache_path(cache_dir, url)
-    if cache_file.exists():
-        return cache_file.read_text(encoding="utf-8"), True
+def fetch_html(session: requests.Session, url: str, cache_dir: Path, *, retry_count: int, sleep_sec: float) -> str:
+    path = _cache_path(cache_dir, url)
+    if path.exists():
+        return path.read_text(encoding="utf-8")
 
     last_error: Exception | None = None
     for attempt in range(retry_count + 1):
@@ -327,9 +287,9 @@ def fetch_html(session: requests.Session, url: str, cache_dir: Path, *, retry_co
             response.raise_for_status()
             response.encoding = response.encoding or "utf-8"
             html = response.text
-            cache_file.parent.mkdir(parents=True, exist_ok=True)
-            cache_file.write_text(html, encoding="utf-8")
-            return html, False
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(html, encoding="utf-8")
+            return html
         except Exception as err:  # noqa: BLE001
             last_error = err
             if attempt < retry_count:
@@ -351,32 +311,30 @@ def _parse_total_units(value: str) -> str:
     return m.group(1) if m else ""
 
 
-def _facts_rows_from_list_rows(rows: list[ListRow]) -> list[dict[str, str]]:
-    result: dict[tuple[str, str], dict[str, str]] = {}
+def _to_facts_rows(rows: list[ListRow]) -> list[dict[str, str]]:
+    dedup: dict[tuple[str, str], dict[str, str]] = {}
     for row in rows:
         key = (row.kind, f"{row.building_name}|{row.address}")
-        if key in result:
+        if key in dedup:
             continue
-        raw_block = " | ".join(
-            [
-                f"交通:{row.access_text}",
-                f"築年数:{row.built_text}",
-                f"階建て:{row.building_floor_count_text}",
-                f"総戸数:{row.total_units_text}",
-                f"詳細URL:{row.detail_url}",
-            ]
-        )
-        evidence_source = row.detail_url or f"{row.kind}:{row.building_name}:{row.address}"
-        result[key] = {
+        dedup[key] = {
             "building_name": row.building_name,
             "address": row.address,
             "access_info": row.access_text,
             "floor_count_text": row.building_floor_count_text,
             "total_units": _parse_total_units(row.total_units_text),
-            "evidence_id": f"mansion_review:{evidence_source}",
-            "raw_block": raw_block,
+            "evidence_id": f"mansion_review:{row.detail_url or row.page_url}",
+            "raw_block": " | ".join(
+                [
+                    f"交通:{row.access_text}",
+                    f"築年数:{row.built_text}",
+                    f"階建て:{row.building_floor_count_text}",
+                    f"総戸数:{row.total_units_text}",
+                    f"詳細URL:{row.detail_url}",
+                ]
+            ),
         }
-    return list(result.values())
+    return list(dedup.values())
 
 
 def _write_facts_csv(rows: list[dict[str, str]], path: Path) -> None:
@@ -401,77 +359,70 @@ def run_crawl(
 ) -> tuple[Path, Path, dict[str, object]]:
     timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
     run_dir = out_root / timestamp
-    all_rows: list[ListRow] = []
-    stats: dict[str, object] = {
-        "pages_total": 0,
-        "rows_total": 0,
-        "errors": [],
-        "rows_by_kind": {},
-        "unique_detail_url_by_kind": {},
-    }
 
     session = requests.Session()
     session.headers.update({"User-Agent": user_agent})
 
+    all_rows: list[ListRow] = []
+    stats: dict[str, object] = {
+        "pages_total": 0,
+        "rows_total": 0,
+        "rows_by_kind": {},
+        "unique_detail_url_by_kind": {},
+        "errors": [],
+    }
+
     for kind in kinds:
         for city_id in city_ids:
-            page1_url = build_city_page_url(kind, city_id, 1)
             try:
-                page1_html, _ = fetch_html(
+                first_html = fetch_html(
                     session,
-                    page1_url,
+                    build_city_page_url(kind, city_id, 1),
                     cache_dir,
                     retry_count=retry_count,
                     sleep_sec=sleep_sec,
                 )
-            except Exception as err:  # noqa: BLE001
-                stats["errors"].append({"kind": kind, "city_id": city_id, "page": 1, "url": page1_url, "error": str(err)})
-                continue
+                total_pages = parse_max_page(first_html, kind=kind, city_id=city_id)
+                if max_pages > 0:
+                    total_pages = min(total_pages, max_pages)
 
-            total_pages = parse_max_page(page1_html, kind=kind, city_id=city_id)
-            if max_pages > 0:
-                total_pages = min(total_pages, max_pages)
-
-            for page_no in range(1, total_pages + 1):
-                page_url = build_city_page_url(kind, city_id, page_no)
-                try:
-                    html, _ = (page1_html, True) if page_no == 1 else fetch_html(
+                for page_no in range(1, total_pages + 1):
+                    url = build_city_page_url(kind, city_id, page_no)
+                    html = first_html if page_no == 1 else fetch_html(
                         session,
-                        page_url,
+                        url,
                         cache_dir,
                         retry_count=retry_count,
                         sleep_sec=sleep_sec,
                     )
-                    rows, _ = parse_list_page(html, page_url, kind, city_id, page_no)
+                    rows, _ = parse_list_page(html, url, kind, city_id, page_no)
                     all_rows.extend(rows)
                     stats["pages_total"] = int(stats["pages_total"]) + 1
-                except Exception as err:  # noqa: BLE001
-                    stats["errors"].append(
-                        {"kind": kind, "city_id": city_id, "page": page_no, "url": page_url, "error": str(err)}
-                    )
-                time.sleep(sleep_sec)
+                    time.sleep(sleep_sec)
+            except Exception as err:  # noqa: BLE001
+                casted = stats["errors"]
+                assert isinstance(casted, list)
+                casted.append({"kind": kind, "city_id": city_id, "error": str(err)})
 
     list_csv = run_dir / f"mansion_review_list_{timestamp}.csv"
     _write_list_csv(all_rows, list_csv)
-    stats["rows_total"] = len(all_rows)
+
     rows_by_kind: dict[str, int] = {}
-    detail_by_kind: dict[str, set[str]] = {}
+    detail_urls_by_kind: dict[str, set[str]] = {}
     for row in all_rows:
         rows_by_kind[row.kind] = rows_by_kind.get(row.kind, 0) + 1
-        detail_by_kind.setdefault(row.kind, set())
+        detail_urls_by_kind.setdefault(row.kind, set())
         if row.detail_url:
-            detail_by_kind[row.kind].add(row.detail_url)
+            detail_urls_by_kind[row.kind].add(row.detail_url)
+    stats["rows_total"] = len(all_rows)
     stats["rows_by_kind"] = rows_by_kind
-    stats["unique_detail_url_by_kind"] = {k: len(v) for k, v in detail_by_kind.items()}
+    stats["unique_detail_url_by_kind"] = {k: len(v) for k, v in detail_urls_by_kind.items()}
 
+    out_csv = list_csv
     if mode == "facts":
-        facts_rows = _facts_rows_from_list_rows(all_rows)
         facts_csv = out_root / "combined" / f"building_facts_{timestamp}.csv"
-        _write_facts_csv(facts_rows, facts_csv)
-        stats["facts_total"] = len(facts_rows)
+        _write_facts_csv(_to_facts_rows(all_rows), facts_csv)
         out_csv = facts_csv
-    else:
-        out_csv = list_csv
 
     run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "stats.json").write_text(json.dumps(stats, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -481,7 +432,7 @@ def run_crawl(
 def main() -> int:
     parser = argparse.ArgumentParser(description="Crawl mansion-review city list pages and export CSV")
     parser.add_argument("--city-ids", default="1616,1619")
-    parser.add_argument("--kinds", default="mansion,chintai")
+    parser.add_argument("--kinds", default="chintai,mansion")
     parser.add_argument("--mode", default="list", choices=["list", "facts"])
     parser.add_argument("--out-dir", default=str(DEFAULT_OUT))
     parser.add_argument("--cache-dir", default=str(DEFAULT_CACHE))
@@ -493,10 +444,8 @@ def main() -> int:
 
     city_ids = parse_csv_arg(args.city_ids)
     kinds = parse_csv_arg(args.kinds)
-    if not city_ids or not kinds:
-        raise SystemExit("--city-ids/--kinds must not be empty")
 
-    out_dir, out_csv, stats = run_crawl(
+    run_dir, out_csv, stats = run_crawl(
         city_ids=city_ids,
         kinds=kinds,
         mode=args.mode,
@@ -507,17 +456,14 @@ def main() -> int:
         retry_count=args.retry_count,
         user_agent=args.user_agent,
     )
-    print(
-        f"[OK] pages_total={stats['pages_total']} rows_total={stats['rows_total']} "
-        f"errors={len(stats['errors'])} out_csv={out_csv}"
-    )
+
+    print(f"[OK] pages_total={stats['pages_total']}")
+    print(f"[OK] rows_total={stats['rows_total']}")
     for kind in kinds:
         print(f"[OK] kind={kind} rows={stats.get('rows_by_kind', {}).get(kind, 0)}")
-        print(
-            f"[OK] kind={kind} unique_detail_url="
-            f"{stats.get('unique_detail_url_by_kind', {}).get(kind, 0)}"
-        )
-    print(f"[OK] stats={out_dir / 'stats.json'}")
+        print(f"[OK] kind={kind} unique_detail_url={stats.get('unique_detail_url_by_kind', {}).get(kind, 0)}")
+    print(f"[OK] out_csv={out_csv}")
+    print(f"[OK] stats={run_dir / 'stats.json'}")
     return 0
 
 

--- a/scripts/mansion_review_list_to_master_import.py
+++ b/scripts/mansion_review_list_to_master_import.py
@@ -49,56 +49,59 @@ def _extract_man_value(text: str) -> str:
     normalized = _clean(text).replace(",", "")
     if not normalized:
         return ""
-    m = re.search(r"(\d+(?:\.\d+)?)\s*万円", normalized)
-    if m:
-        return m.group(1)
+
+    man = re.search(r"(\d+(?:\.\d+)?)\s*万円", normalized)
+    if man:
+        return man.group(1)
+
     yen = re.search(r"(\d+)\s*円", normalized)
-    if not yen:
-        return ""
-    value = int(yen.group(1)) / 10000
-    return f"{value:.4f}".rstrip("0").rstrip(".")
+    if yen:
+        value = int(yen.group(1)) / 10000
+        return f"{value:.4f}".rstrip("0").rstrip(".")
+
+    return ""
 
 
-def _extract_area(text: str) -> str:
+def _extract_area_sqm(text: str) -> str:
     m = re.search(r"(\d+(?:\.\d+)?)\s*(?:㎡|m²|m2)", _clean(text))
     return m.group(1) if m else ""
 
 
 def _simple_layout(value: str | None) -> str:
     layout = _clean(value)
-    if len(layout) > 40:
-        return ""
-    return layout
+    return "" if len(layout) > 40 else layout
 
 
-def _build_raw_block(row: dict[str, str], *, kind: str) -> str:
-    parts = [
-        f"種類:{_clean(row.get('kind'))}",
-        f"市区:{_clean(row.get('ward'))}",
-        f"価格賃料:{_clean(row.get('price_or_rent_text'))}",
-        f"間取り:{_clean(row.get('layout_text'))}",
-        f"面積:{_clean(row.get('area_text'))}",
-        f"所在階:{_clean(row.get('floor_text'))}",
-        f"向き:{_clean(row.get('direction_text'))}",
-        f"坪単価:{_clean(row.get('tsubo_unit_price_text'))}",
-        f"交通:{_clean(row.get('access_text'))}",
-        f"築年数:{_clean(row.get('built_text'))}",
-        f"階建て:{_clean(row.get('building_floor_count_text'))}",
-        f"総戸数:{_clean(row.get('total_units_text'))}",
-        f"詳細URL:{_clean(row.get('detail_url'))}",
-        f"一覧URL:{_clean(row.get('page_url'))}",
+def _build_raw_block(row: dict[str, str]) -> str:
+    fields = [
+        ("種類", row.get("kind")),
+        ("市区", row.get("ward")),
+        ("価格賃料", row.get("price_or_rent_text")),
+        ("管理費", row.get("fee_text")),
+        ("坪単価", row.get("tsubo_unit_price_text")),
+        ("敷金", row.get("deposit_text")),
+        ("礼金", row.get("key_money_text")),
+        ("専有面積", row.get("area_text")),
+        ("間取り", row.get("layout_text")),
+        ("所在階", row.get("floor_text")),
+        ("向き", row.get("direction_text")),
+        ("住所", row.get("address")),
+        ("交通", row.get("access_text")),
+        ("築年数", row.get("built_text")),
+        ("階建て", row.get("building_floor_count_text")),
+        ("総戸数", row.get("total_units_text")),
+        ("詳細URL", row.get("detail_url")),
+        ("一覧URL", row.get("page_url")),
     ]
-    if kind == "chintai":
-        fee = _clean(row.get("fee_text"))
-        parts.extend([f"管理費:{fee}", f"敷金:{_clean(row.get('deposit_text'))}", f"礼金:{_clean(row.get('key_money_text'))}"])
-    return " | ".join(part for part in parts if not part.endswith(":"))
+    return " | ".join(f"{k}:{_clean(v)}" for k, v in fields if _clean(v))
 
 
 def _evidence_id(row: dict[str, str]) -> str:
     detail_url = _clean(row.get("detail_url"))
-    material = "|".join(
-        _clean(row.get(key))
-        for key in (
+    payload = "|".join(
+        _clean(row.get(k))
+        for k in (
+            "kind",
             "price_or_rent_text",
             "fee_text",
             "tsubo_unit_price_text",
@@ -110,18 +113,17 @@ def _evidence_id(row: dict[str, str]) -> str:
             "direction_text",
         )
     )
-    digest = hashlib.sha1(material.encode("utf-8")).hexdigest()[:12]
+    digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()[:12]
     if detail_url:
         return f"mansion_review:{detail_url}#l={digest}"
-    fallback = hashlib.sha1((material + _clean(row.get("building_name"))).encode("utf-8")).hexdigest()[:16]
-    return f"mansion_review:list:{fallback}"
+    return f"mansion_review:list:{digest}"
 
 
 def convert(input_csv: Path, output_csv: Path, updated_at: str | None) -> int:
     updated = updated_at or _parse_updated_at_from_filename(input_csv)
     output_csv.parent.mkdir(parents=True, exist_ok=True)
-    written = 0
 
+    count = 0
     with input_csv.open("r", encoding="utf-8-sig", newline="") as in_fh, output_csv.open(
         "w", encoding="utf-8-sig", newline=""
     ) as out_fh:
@@ -129,26 +131,25 @@ def convert(input_csv: Path, output_csv: Path, updated_at: str | None) -> int:
         writer = csv.DictWriter(out_fh, fieldnames=list(MASTER_COLUMNS))
         writer.writeheader()
 
-        for src in reader:
-            kind = _clean(src.get("kind")).lower()
-            if kind not in {"mansion", "chintai"}:
+        for row in reader:
+            kind = _clean(row.get("kind")).lower()
+            if kind not in {"chintai", "mansion"}:
                 continue
-
             writer.writerow(
                 {
-                    "page": _clean(src.get("detail_url")) or _clean(src.get("page_url")),
+                    "page": _clean(row.get("detail_url")) or _clean(row.get("page_url")),
                     "category": kind,
                     "updated_at": updated,
-                    "building_name": _clean(src.get("building_name")),
+                    "building_name": _clean(row.get("building_name")),
                     "room": "",
-                    "address": _clean(src.get("address")),
-                    "rent_man": _extract_man_value(src.get("price_or_rent_text") or ""),
-                    "fee_man": _extract_man_value(src.get("fee_text") or "") if kind == "chintai" else "",
-                    "floor": _clean(src.get("floor_text")),
-                    "layout": _simple_layout(src.get("layout_text")),
-                    "area_sqm": _extract_area(src.get("area_text") or ""),
+                    "address": _clean(row.get("address")),
+                    "rent_man": _extract_man_value(_clean(row.get("price_or_rent_text"))),
+                    "fee_man": _extract_man_value(_clean(row.get("fee_text"))) if kind == "chintai" else "",
+                    "floor": _clean(row.get("floor_text")),
+                    "layout": _simple_layout(row.get("layout_text")),
+                    "area_sqm": _extract_area_sqm(_clean(row.get("area_text"))),
                     "availability_raw": "",
-                    "built_raw": _clean(src.get("built_text")),
+                    "built_raw": _clean(row.get("built_text")),
                     "age_years": "",
                     "structure": "",
                     "built_year_month": "",
@@ -156,26 +157,23 @@ def convert(input_csv: Path, output_csv: Path, updated_at: str | None) -> int:
                     "availability_date": "",
                     "availability_flag_immediate": "",
                     "structure_raw": "",
-                    "raw_block": _build_raw_block(src, kind=kind),
-                    "evidence_id": _evidence_id(src),
+                    "raw_block": _build_raw_block(row),
+                    "evidence_id": _evidence_id(row),
                 }
             )
-            written += 1
-
-    return written
+            count += 1
+    return count
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Convert mansion_review_list CSV to ingest_master_import-compatible CSV")
+    parser = argparse.ArgumentParser(description="Convert mansion_review list CSV to master_import CSV")
     parser.add_argument("--input-csv", required=True)
     parser.add_argument("--output-csv", required=True)
     parser.add_argument("--updated-at", default="")
     args = parser.parse_args()
 
-    input_csv = Path(args.input_csv)
-    output_csv = Path(args.output_csv)
-    count = convert(input_csv, output_csv, args.updated_at or None)
-    print(f"converted_rows={count} output={output_csv}")
+    converted = convert(Path(args.input_csv), Path(args.output_csv), args.updated_at or None)
+    print(f"converted_rows={converted} output={args.output_csv}")
 
 
 if __name__ == "__main__":

--- a/tests/test_mansion_review_crawl_to_csv.py
+++ b/tests/test_mansion_review_crawl_to_csv.py
@@ -14,7 +14,7 @@ parse_list_page = crawl.parse_list_page
 parse_max_page = crawl.parse_max_page
 
 
-def test_parse_list_page_chintai_uses_recommend_row_and_splits_rent_fee() -> None:
+def test_parse_list_page_chintai_extracts_required_11_fields() -> None:
     html = """
     <html><body>
       <li class="property-detail-list-item">
@@ -29,12 +29,15 @@ def test_parse_list_page_chintai_uses_recommend_row_and_splits_rent_fee() -> Non
           </dl>
         </div>
         <table class="recommendTable">
-          <thead>
-            <tr><th>賃料</th><th>管理費</th><th>敷金</th><th>礼金</th><th>専有面積</th><th>間取り</th></tr>
-          </thead>
           <tbody class="recommend_row">
-            <tr><td>7.8万円</td><td>5,000円</td><td>1ヶ月</td><td>2ヶ月</td><td>41.2㎡</td><td>1LDK</td></tr>
-            <tr><td>8.4万円</td><td>6,000円</td><td>1ヶ月</td><td>2ヶ月</td><td>44.2㎡</td><td>2LDK</td></tr>
+            <tr>
+              <td data-th="賃料">7.8万円</td>
+              <td data-th="管理費">5,000円</td>
+              <td data-th="敷金">1ヶ月</td>
+              <td data-th="礼金">2ヶ月</td>
+              <td data-th="専有面積">41.2㎡</td>
+              <td data-th="間取り">1LDK</td>
+            </tr>
           </tbody>
         </table>
         <a href="/chintai/91001">詳細</a>
@@ -48,24 +51,22 @@ def test_parse_list_page_chintai_uses_recommend_row_and_splits_rent_fee() -> Non
         city_id="1616",
         page_no=1,
     )
-    assert len(rows) == 2
-    assert debug.selector_hits["rows"] == 2
-
-    first = rows[0]
-    assert first.address == "福岡県北九州市門司区港町1-2-3"
-    assert first.access_text == "JR門司港駅 徒歩8分"
-    assert first.built_text == "築16年"
-    assert first.building_floor_count_text == "10階建て"
-    assert first.total_units_text == "45戸"
-    assert first.price_or_rent_text == "7.8万円"
-    assert first.fee_text == "5,000円"
-    assert first.deposit_text == "1ヶ月"
-    assert first.key_money_text == "2ヶ月"
-    assert first.area_text == "41.2㎡"
-    assert first.layout_text == "1LDK"
+    assert debug["rows"] == 1
+    row = rows[0]
+    assert row.address == "福岡県北九州市門司区港町1-2-3"
+    assert row.access_text == "JR門司港駅 徒歩8分"
+    assert row.built_text == "築16年"
+    assert row.building_floor_count_text == "10階建て"
+    assert row.total_units_text == "45戸"
+    assert row.price_or_rent_text == "7.8万円"
+    assert row.fee_text == "5,000円"
+    assert row.deposit_text == "1ヶ月"
+    assert row.key_money_text == "2ヶ月"
+    assert row.area_text == "41.2㎡"
+    assert row.layout_text == "1LDK"
 
 
-def test_parse_list_page_mansion_uses_price_tsubo_area_layout_floor_direction() -> None:
+def test_parse_list_page_mansion_extracts_required_11_fields() -> None:
     html = """
     <html><body>
       <article class="property-detail-list-item">
@@ -80,12 +81,15 @@ def test_parse_list_page_mansion_uses_price_tsubo_area_layout_floor_direction() 
           </table>
         </div>
         <table class="recommendTable">
-          <thead>
-            <tr><th>価格</th><th>坪単価</th><th>専有面積</th><th>間取り</th><th>所在階</th><th>向き</th></tr>
-          </thead>
           <tbody class="recommend_row">
-            <tr><td>3,180万円</td><td>159万円/坪</td><td>66.0㎡</td><td>2LDK</td><td>7階</td><td>南</td></tr>
-            <tr><td>4,200万円</td><td>192万円/坪</td><td>72.0㎡</td><td>3LDK</td><td>10階</td><td>東</td></tr>
+            <tr>
+              <td data-th="価格">3,180万円</td>
+              <td data-th="坪単価">159万円/坪</td>
+              <td data-th="専有面積">66.0㎡</td>
+              <td data-th="間取り">2LDK</td>
+              <td data-th="所在階">7階</td>
+              <td data-th="向き">南</td>
+            </tr>
           </tbody>
         </table>
         <a href="/mansion/80011">物件詳細</a>
@@ -99,73 +103,28 @@ def test_parse_list_page_mansion_uses_price_tsubo_area_layout_floor_direction() 
         city_id="1619",
         page_no=1,
     )
-    assert len(rows) == 2
-    assert rows[0].price_or_rent_text == "3,180万円"
-    assert rows[0].tsubo_unit_price_text == "159万円/坪"
-    assert rows[0].area_text == "66.0㎡"
-    assert rows[0].layout_text == "2LDK"
-    assert rows[0].floor_text == "7階"
-    assert rows[0].direction_text == "南"
-    assert rows[0].fee_text == ""
+    row = rows[0]
+    assert row.address == "福岡県北九州市小倉北区浅野2-1-1"
+    assert row.access_text == "JR小倉駅 徒歩7分"
+    assert row.built_text == "築12年"
+    assert row.building_floor_count_text == "20階建て"
+    assert row.total_units_text == "120戸"
+    assert row.price_or_rent_text == "3,180万円"
+    assert row.tsubo_unit_price_text == "159万円/坪"
+    assert row.area_text == "66.0㎡"
+    assert row.layout_text == "2LDK"
+    assert row.floor_text == "7階"
+    assert row.direction_text == "南"
 
 
-def test_parse_list_page_chintai_without_table_header_uses_fixed_row_order() -> None:
-    html = """
-    <html><body>
-      <li class="property-detail-list-item">
-        <h3>門司ヘッダなしレジデンス</h3>
-        <div class="property-detail-content_main">
-          <dl>
-            <dt>住所</dt><dd>福岡県北九州市門司区東本町1-1-1</dd>
-            <dt>交通</dt><dd>JR門司港駅 徒歩9分</dd>
-            <dt>築年数</dt><dd>築18年</dd>
-            <dt>階建て</dt><dd>9階建て</dd>
-            <dt>総戸数</dt><dd>30戸</dd>
-          </dl>
-        </div>
-        <table class="recommendTable">
-          <tbody class="recommend_row">
-            <tr><td>6.8万円</td><td>4,000円</td><td>1ヶ月</td><td>1ヶ月</td><td>33.5㎡</td><td>1DK</td></tr>
-          </tbody>
-        </table>
-      </li>
-    </body></html>
-    """
-    rows, _ = parse_list_page(
-        html,
-        page_url="https://www.mansion-review.jp/chintai/city/1616.html",
-        kind="chintai",
-        city_id="1616",
-        page_no=1,
-    )
-    assert len(rows) == 1
-    assert rows[0].price_or_rent_text == "6.8万円"
-    assert rows[0].fee_text == "4,000円"
-    assert rows[0].deposit_text == "1ヶ月"
-    assert rows[0].key_money_text == "1ヶ月"
-    assert rows[0].area_text == "33.5㎡"
-    assert rows[0].layout_text == "1DK"
-
-
-def test_parse_list_page_mansion_without_table_header_uses_fixed_row_order() -> None:
+def test_parse_list_page_headerless_uses_fixed_column_order() -> None:
     html = """
     <html><body>
       <article class="property-detail-list-item">
-        <h3>門司ヘッダなし分譲</h3>
-        <div class="property-detail-content_main">
-          <table>
-            <tr><th>住所</th><td>福岡県北九州市門司区東港町7-8-9</td></tr>
-            <tr><th>交通</th><td>JR門司港駅 徒歩6分</td></tr>
-            <tr><th>築年数</th><td>築14年</td></tr>
-            <tr><th>階建て</th><td>14階建て</td></tr>
-            <tr><th>総戸数</th><td>85戸</td></tr>
-          </table>
-        </div>
-        <table class="recommendTable">
-          <tbody class="recommend_row">
-            <tr><td>2,980万円</td><td>139万円/坪</td><td>63.0㎡</td><td>2LDK</td><td>8階</td><td>南西</td></tr>
-          </tbody>
-        </table>
+        <div class="property-detail-content_main"></div>
+        <table class="recommendTable"><tbody class="recommend_row">
+          <tr><td>2,980万円</td><td>139万円/坪</td><td>63.0㎡</td><td>2LDK</td><td>8階</td><td>南西</td></tr>
+        </tbody></table>
       </article>
     </body></html>
     """
@@ -176,7 +135,6 @@ def test_parse_list_page_mansion_without_table_header_uses_fixed_row_order() -> 
         city_id="1616",
         page_no=1,
     )
-    assert len(rows) == 1
     assert rows[0].price_or_rent_text == "2,980万円"
     assert rows[0].tsubo_unit_price_text == "139万円/坪"
     assert rows[0].area_text == "63.0㎡"
@@ -185,11 +143,10 @@ def test_parse_list_page_mansion_without_table_header_uses_fixed_row_order() -> 
     assert rows[0].direction_text == "南西"
 
 
-def test_parse_list_page_does_not_use_property_card_fallback() -> None:
+def test_parse_list_page_does_not_use_non_target_card_selector() -> None:
     html = """
     <html><body>
       <section class="property-card">
-        <h2 class="property-name">旧形式カード</h2>
         <table class="recommendTable"><tbody class="recommend_row"><tr><td>1</td></tr></tbody></table>
       </section>
     </body></html>
@@ -202,7 +159,7 @@ def test_parse_list_page_does_not_use_property_card_fallback() -> None:
         page_no=1,
     )
     assert rows == []
-    assert debug.selector_hits["cards"] == 0
+    assert debug["cards"] == 0
 
 
 def test_parse_max_page_from_links() -> None:


### PR DESCRIPTION
### Motivation
- The existing Mansion Review pipeline contained brittle, repair-style extraction and fallback logic causing missing/misaligned listing columns; this change rebuilds the pipeline from a strict, minimal DOM contract to ensure deterministic CSV output.
- The goal was to remove unnecessary/special-case logic and provide a clear 1-row-per-listing mapping from page DOM to CSV so downstream `master_import` → DB → summary → render → front will be stable.

### Description
- Rewrote `scripts/mansion_review_crawl_to_csv.py` to use only `.property-detail-content_main` for building facts and `table.recommendTable > tbody.recommend_row > tr` for listings, and removed fallback/representative/raw_block re-extraction paths. The parser now maps chintai rows to `賃料 / 管理費 / 敷金 / 礼金 / 専有面積 / 間取り` and mansion rows to `価格 / 坪単価 / 専有面積 / 間取り / 所在階 / 向き` deterministically.
- Rebuilt `scripts/mansion_review_list_to_master_import.py` into a minimal, deterministic converter aligned with the existing ingest contract, producing `master_import` CSV fields, `raw_block`, and stable `evidence_id` without touching shared ingest code.
- Replaced/updated Mansion Review-focused tests under `tests/test_mansion_review_crawl_to_csv.py` and kept a focused contract test for `scripts/mansion_review_list_to_master_import.py` to validate the new selectors and column mapping.
- Preserved run stats/logging (`pages_total`, `rows_total`, `kind=... rows=...`, `kind=... unique_detail_url=...`) and did not modify shared files, `public.sqlite3`, `dist`, or front-end templates.

### Testing
- Ran `pytest -q tests/test_mansion_review_crawl_to_csv.py tests/test_mansion_review_list_to_master_import.py` and the suite passed (`6 passed`).
- Ran targeted backend tests `pytest -q tests/test_master_import.py tests/test_building_summaries.py -k "mansion_review or sale" tests/test_build_smoke.py` which validated related master-import/summary expectations (`3 passed, 18 deselected`).
- Attempted live fetch of the target pages but an outbound proxy returned `403 Forbidden`, so online crawl verification was blocked in this environment; the scripts and logging remain in place for a live run in a network-enabled environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91d49cb548326b1097bcc19f6f761)