### PR TITLE
Single-run Mansion Review crawl: emit building_facts + master_import CSVs and update PS1 pipeline

### DIFF
--- a/scripts/mansion_review_crawl_to_csv.py
+++ b/scripts/mansion_review_crawl_to_csv.py
@@ -56,10 +56,35 @@ FACTS_COLUMNS = (
     "building_name",
     "address",
     "access_info",
+    "built_text",
     "floor_count_text",
     "total_units",
     "evidence_id",
+)
+
+MASTER_COLUMNS = (
+    "page",
+    "category",
+    "updated_at",
+    "building_name",
+    "room",
+    "address",
+    "rent_man",
+    "fee_man",
+    "floor",
+    "layout",
+    "area_sqm",
+    "availability_raw",
+    "built_raw",
+    "age_years",
+    "structure",
+    "built_year_month",
+    "built_age_years",
+    "availability_date",
+    "availability_flag_immediate",
+    "structure_raw",
     "raw_block",
+    "evidence_id",
 )
 
 CHINTAI_ORDER = ["賃料", "管理費", "敷金", "礼金", "専有面積", "間取り"]
@@ -366,18 +391,10 @@ def _to_facts_rows(rows: list[ListRow]) -> list[dict[str, str]]:
             "building_name": row.building_name,
             "address": row.address,
             "access_info": row.access_text,
+            "built_text": row.built_text,
             "floor_count_text": row.building_floor_count_text,
             "total_units": _parse_total_units(row.total_units_text),
             "evidence_id": f"mansion_review:{row.detail_url or row.page_url}",
-            "raw_block": " | ".join(
-                [
-                    f"交通:{row.access_text}",
-                    f"築年数:{row.built_text}",
-                    f"階建て:{row.building_floor_count_text}",
-                    f"総戸数:{row.total_units_text}",
-                    f"詳細URL:{row.detail_url}",
-                ]
-            ),
         }
     return list(dedup.values())
 
@@ -390,18 +407,116 @@ def _write_facts_csv(rows: list[dict[str, str]], path: Path) -> None:
         writer.writerows(rows)
 
 
+def _extract_man_value(text: str) -> str:
+    normalized = normalize_space(text).replace(",", "")
+    if not normalized:
+        return ""
+    man = re.search(r"(\d+(?:\.\d+)?)\s*万円", normalized)
+    if man:
+        return man.group(1)
+    yen = re.search(r"(\d+)\s*円", normalized)
+    if yen:
+        value = int(yen.group(1)) / 10000
+        return f"{value:.4f}".rstrip("0").rstrip(".")
+    return ""
+
+
+def _extract_area_sqm(text: str) -> str:
+    m = re.search(r"(\d+(?:\.\d+)?)\s*(?:㎡|m²|m2)", normalize_space(text))
+    return m.group(1) if m else ""
+
+
+def _listing_evidence_id(row: ListRow) -> str:
+    payload = "|".join(
+        normalize_space(getattr(row, k))
+        for k in (
+            "kind",
+            "price_or_rent_text",
+            "fee_text",
+            "tsubo_unit_price_text",
+            "deposit_text",
+            "key_money_text",
+            "area_text",
+            "layout_text",
+            "floor_text",
+            "direction_text",
+        )
+    )
+    digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()[:12]
+    return f"mansion_review:{row.detail_url or row.page_url}#l={digest}"
+
+
+def _to_master_rows(rows: list[ListRow], updated_at: str) -> list[dict[str, str]]:
+    out: list[dict[str, str]] = []
+    for row in rows:
+        raw_fields = [
+            ("kind", row.kind),
+            ("賃料/価格", row.price_or_rent_text),
+            ("管理費", row.fee_text),
+            ("坪単価", row.tsubo_unit_price_text),
+            ("敷金", row.deposit_text),
+            ("礼金", row.key_money_text),
+            ("専有面積", row.area_text),
+            ("間取り", row.layout_text),
+            ("所在階", row.floor_text),
+            ("向き", row.direction_text),
+            ("住所", row.address),
+            ("交通", row.access_text),
+            ("築年数", row.built_text),
+            ("階建て", row.building_floor_count_text),
+            ("総戸数", row.total_units_text),
+            ("一覧URL", row.page_url),
+            ("詳細URL", row.detail_url),
+        ]
+        raw_block = " | ".join(f"{k}:{normalize_space(v)}" for k, v in raw_fields if normalize_space(v))
+        out.append(
+            {
+                "page": row.detail_url or row.page_url,
+                "category": row.kind,
+                "updated_at": updated_at,
+                "building_name": row.building_name,
+                "room": "",
+                "address": row.address,
+                "rent_man": _extract_man_value(row.price_or_rent_text),
+                "fee_man": _extract_man_value(row.fee_text) if row.kind == "chintai" else "",
+                "floor": row.floor_text,
+                "layout": row.layout_text,
+                "area_sqm": _extract_area_sqm(row.area_text),
+                "availability_raw": "",
+                "built_raw": row.built_text,
+                "age_years": "",
+                "structure": "",
+                "built_year_month": "",
+                "built_age_years": "",
+                "availability_date": "",
+                "availability_flag_immediate": "",
+                "structure_raw": "",
+                "raw_block": raw_block,
+                "evidence_id": _listing_evidence_id(row),
+            }
+        )
+    return out
+
+
+def _write_master_csv(rows: list[dict[str, str]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8-sig", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(MASTER_COLUMNS))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
 def run_crawl(
     *,
     city_ids: list[str],
     kinds: list[str],
-    mode: str,
     out_root: Path,
     cache_dir: Path,
     sleep_sec: float,
     max_pages: int,
     retry_count: int,
     user_agent: str,
-) -> tuple[Path, Path, dict[str, object]]:
+) -> tuple[Path, dict[str, Path], dict[str, object]]:
     timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
     run_dir = out_root / timestamp
 
@@ -440,17 +555,23 @@ def run_crawl(
                         retry_count=retry_count,
                         sleep_sec=sleep_sec,
                     )
-                    rows, _ = parse_list_page(html, url, kind, city_id, page_no)
+                    rows, page_stats = parse_list_page(html, url, kind, city_id, page_no)
                     all_rows.extend(rows)
                     stats["pages_total"] = int(stats["pages_total"]) + 1
+                    print(f"[INFO] kind={kind} city_id={city_id} page={page_no}/{total_pages} rows={page_stats['rows']}")
                     time.sleep(sleep_sec)
             except Exception as err:  # noqa: BLE001
                 casted = stats["errors"]
                 assert isinstance(casted, list)
                 casted.append({"kind": kind, "city_id": city_id, "error": str(err)})
 
+    run_dir.mkdir(parents=True, exist_ok=True)
     list_csv = run_dir / f"mansion_review_list_{timestamp}.csv"
     _write_list_csv(all_rows, list_csv)
+    facts_csv = run_dir / "building_facts.csv"
+    master_csv = run_dir / "mansion_review_master_import.csv"
+    _write_facts_csv(_to_facts_rows(all_rows), facts_csv)
+    _write_master_csv(_to_master_rows(all_rows, datetime.utcnow().strftime("%Y/%m/%d %H:%M")), master_csv)
 
     rows_by_kind: dict[str, int] = {}
     detail_urls_by_kind: dict[str, set[str]] = {}
@@ -463,22 +584,19 @@ def run_crawl(
     stats["rows_by_kind"] = rows_by_kind
     stats["unique_detail_url_by_kind"] = {k: len(v) for k, v in detail_urls_by_kind.items()}
 
-    out_csv = list_csv
-    if mode == "facts":
-        facts_csv = out_root / "combined" / f"building_facts_{timestamp}.csv"
-        _write_facts_csv(_to_facts_rows(all_rows), facts_csv)
-        out_csv = facts_csv
-
-    run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "stats.json").write_text(json.dumps(stats, ensure_ascii=False, indent=2), encoding="utf-8")
-    return run_dir, out_csv, stats
+    outputs = {
+        "list_csv": list_csv,
+        "building_facts_csv": facts_csv,
+        "master_import_csv": master_csv,
+    }
+    return run_dir, outputs, stats
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Crawl mansion-review city list pages and export CSV")
     parser.add_argument("--city-ids", default="1616,1619")
     parser.add_argument("--kinds", default="chintai,mansion")
-    parser.add_argument("--mode", default="list", choices=["list", "facts"])
     parser.add_argument("--out-dir", default=str(DEFAULT_OUT))
     parser.add_argument("--cache-dir", default=str(DEFAULT_CACHE))
     parser.add_argument("--sleep-sec", type=float, default=0.7)
@@ -490,10 +608,9 @@ def main() -> int:
     city_ids = parse_csv_arg(args.city_ids)
     kinds = parse_csv_arg(args.kinds)
 
-    run_dir, out_csv, stats = run_crawl(
+    run_dir, outputs, stats = run_crawl(
         city_ids=city_ids,
         kinds=kinds,
-        mode=args.mode,
         out_root=Path(args.out_dir),
         cache_dir=Path(args.cache_dir),
         sleep_sec=args.sleep_sec,
@@ -507,7 +624,9 @@ def main() -> int:
     for kind in kinds:
         print(f"[OK] kind={kind} rows={stats.get('rows_by_kind', {}).get(kind, 0)}")
         print(f"[OK] kind={kind} unique_detail_url={stats.get('unique_detail_url_by_kind', {}).get(kind, 0)}")
-    print(f"[OK] out_csv={out_csv}")
+    print(f"[OK] list_csv={outputs['list_csv']}")
+    print(f"[OK] building_facts_csv={outputs['building_facts_csv']}")
+    print(f"[OK] master_import_csv={outputs['master_import_csv']}")
     print(f"[OK] stats={run_dir / 'stats.json'}")
     return 0
 

--- a/scripts/run_mansion_review_crawl.ps1
+++ b/scripts/run_mansion_review_crawl.ps1
@@ -2,7 +2,6 @@ param(
   [string]$RepoPath = (Resolve-Path (Join-Path $PSScriptRoot "..") | Select-Object -ExpandProperty Path),
   [string]$CityIds = "1616,1619",
   [string]$Kinds = "mansion,chintai",
-  [string]$Mode = "list",
   [double]$SleepSec = 0.7,
   [int]$MaxPages = 0
 )
@@ -32,13 +31,12 @@ if (-not (Test-Path $PY)) { throw ".venv python not found: $PY. Run scripts/setu
 & $PY (Join-Path $REPO "scripts/mansion_review_crawl_to_csv.py") `
   --city-ids $CityIds `
   --kinds $Kinds `
-  --mode $Mode `
   --sleep-sec $SleepSec `
   --max-pages $MaxPages
 
 <#
 Example:
-pwsh scripts/run_mansion_review_crawl.ps1 -CityIds "1616,1619" -Kinds "mansion,chintai" -Mode list -SleepSec 0.7 -MaxPages 0
+pwsh scripts/run_mansion_review_crawl.ps1 -CityIds "1616,1619" -Kinds "mansion,chintai" -SleepSec 0.7 -MaxPages 0
 
 Notes:
 -MaxPages 0 : 自動ページング（ページネーションリンク推定。異常値時は次へ追跡で安全停止）

--- a/scripts/run_mansion_review_facts_to_db.ps1
+++ b/scripts/run_mansion_review_facts_to_db.ps1
@@ -3,7 +3,7 @@ param(
   [string]$CityIds = "1616,1619",
   [string]$Kinds = "mansion,chintai",
   [double]$SleepSec = 0.7,
-  [int]$MaxPages = 3,
+  [int]$MaxPages = 0,
   [string]$Merge = "fill_only",
   [switch]$RunPublish = $true
 )
@@ -23,26 +23,39 @@ if (-not (Test-Path $py)) { throw ".venv python not found: $py. Run scripts/setu
 & $py (Join-Path $repo "scripts/mansion_review_crawl_to_csv.py") `
   --city-ids $CityIds `
   --kinds $Kinds `
-  --mode facts `
   --sleep-sec $SleepSec `
   --max-pages $MaxPages
 if ($LASTEXITCODE -ne 0) { throw "mansion_review_crawl_to_csv.py failed" }
 
-$factsCsv = Get-ChildItem -Path (Join-Path $repo "tmp\manual\outputs\mansion_review\combined") -Filter "building_facts_*.csv" -File |
+$runDir = Get-ChildItem -Path (Join-Path $repo "tmp\manual\outputs\mansion_review") -Directory |
   Sort-Object LastWriteTime -Descending |
   Select-Object -First 1
-if (-not $factsCsv) { throw "building_facts CSV not found under tmp/manual/outputs/mansion_review/combined" }
-Write-Host "[OK] facts_csv=$($factsCsv.FullName)"
+if (-not $runDir) { throw "mansion_review output run directory not found" }
+
+$factsCsv = Join-Path $runDir.FullName "building_facts.csv"
+$masterCsv = Join-Path $runDir.FullName "mansion_review_master_import.csv"
+if (-not (Test-Path $factsCsv)) { throw "building_facts.csv not found under $($runDir.FullName)" }
+if (-not (Test-Path $masterCsv)) { throw "mansion_review_master_import.csv not found under $($runDir.FullName)" }
+Write-Host "[OK] facts_csv=$factsCsv"
+Write-Host "[OK] master_csv=$masterCsv"
 
 $dbPath = Join-Path $repo "data\tatemono_map.sqlite3"
-& $py -m tatemono_map.building_registry.ingest_building_facts --db $dbPath --csv $factsCsv.FullName --source mansion_review_facts --merge $Merge
+& $py -m tatemono_map.building_registry.ingest_building_facts --db $dbPath --csv $factsCsv --source mansion_review_facts --merge $Merge
 if ($LASTEXITCODE -ne 0) { throw "ingest_building_facts failed" }
 Write-Host "[OK] ingest_building_facts db=$dbPath merge=$Merge"
+
+& $py -m tatemono_map.building_registry.ingest_master_import --db $dbPath --csv $masterCsv --source mansion_review
+if ($LASTEXITCODE -ne 0) { throw "ingest_master_import failed" }
+Write-Host "[OK] ingest_master_import db=$dbPath source=mansion_review"
 
 if ($RunPublish) {
   & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $repo "scripts\publish_public.ps1") -RepoPath $repo
   if ($LASTEXITCODE -ne 0) { throw "publish_public.ps1 failed" }
   Write-Host "[OK] publish_public data/public/public.sqlite3"
+
+  & $py -m tatemono_map.render.build --db-path data/public/public.sqlite3 --output-dir dist
+  if ($LASTEXITCODE -ne 0) { throw "render build failed" }
+  Write-Host "[OK] render dist/"
 
   & $py -m tatemono_map.cli.export_buildings_json --db data/public/public.sqlite3 --out dist/data/buildings.v2.min.json --format v2min
   if ($LASTEXITCODE -ne 0) { throw "export buildings.v2.min.json failed" }

--- a/scripts/run_mansion_review_listfacts_to_db.ps1
+++ b/scripts/run_mansion_review_listfacts_to_db.ps1
@@ -15,15 +15,12 @@ $ErrorActionPreference = "Stop"
 $repo = (Resolve-Path $RepoPath).Path
 if (-not (Test-Path (Join-Path $repo ".git"))) { throw "Not a git repository: $repo" }
 
-$effectiveMaxPages = $MaxPages
-if ($effectiveMaxPages -le 0) { $effectiveMaxPages = 3 }
-
 & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $repo "scripts\run_mansion_review_facts_to_db.ps1") `
   -RepoPath $repo `
   -CityIds $CityIds `
   -Kinds $Kinds `
   -SleepSec $SleepSec `
-  -MaxPages $effectiveMaxPages `
+  -MaxPages $MaxPages `
   -Merge $Merge `
   -RunPublish:$RunPublish
 if ($LASTEXITCODE -ne 0) { throw "run_mansion_review_facts_to_db.ps1 failed" }


### PR DESCRIPTION
### Motivation
- Ensure Mansion Review data flows from a single crawl through CSV → DB → summary → render → front without double-crawling, and produce building-side and listing-side outputs that match the fixed spec for rental (`chintai`) and sale (`mansion`) rows.

### Description
- Updated `scripts/mansion_review_crawl_to_csv.py` to perform one crawl and emit two CSVs (`building_facts.csv` and `mansion_review_master_import.csv`) with building facts extracted from `.property-detail-content_main` and listing rows from `recommendTable > tbody.recommend_row > tr`, and added master-compatible columns and evidence ids. 
- Implemented explicit `kind`-based mapping so `chintai` rows map to rental fields and `mansion` rows map to sale fields (price/坪単価/面積/間取り/所在階/向き). 
- Added lightweight progress logging during crawl with lines like `[INFO] kind=… city_id=… page=current/total rows=…` and removed the previous `--mode` branching so crawler always emits both outputs. 
- Updated PowerShell orchestration scripts to run the single crawl then ingest both CSVs and perform publish + render: `scripts/run_mansion_review_crawl.ps1` (crawler invocation), `scripts/run_mansion_review_facts_to_db.ps1` (crawl → `ingest_building_facts` → `ingest_master_import` → `publish_public` → `render`), and `scripts/run_mansion_review_listfacts_to_db.ps1` (pass-through `-MaxPages`).

### Testing
- Ran unit tests with `python -m pytest tests/test_mansion_review_crawl_to_csv.py tests/test_mansion_review_list_to_master_import.py`, and all tests passed (`7 passed`).
- Executed the crawler locally with `python scripts/mansion_review_crawl_to_csv.py --city-ids 1616,1619 --kinds chintai,mansion --sleep-sec 0.2 --max-pages 1`, which produced the expected two CSV outputs but fetched 0 rows in this environment due to outbound proxy 403 errors when contacting `mansion-review.jp` (see `tmp/manual/outputs/.../stats.json`).
- Ran DB ingest and render steps with `PYTHONPATH=src python -m tatemono_map.building_registry.ingest_building_facts ...`, `PYTHONPATH=src python -m tatemono_map.building_registry.ingest_master_import ...`, and `PYTHONPATH=src python -m tatemono_map.render.build ...`, and they completed successfully against the generated CSVs (results were zero-row ingests due to the blocked crawl); `publish_public.ps1` could not be run here because `pwsh` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da08ffc1a883268e0fe8a02e3a3aed)