### PR TITLE
Fix Mansion Review recommend_row extraction misalignment

### DIFF
--- a/scripts/mansion_review_crawl_to_csv.py
+++ b/scripts/mansion_review_crawl_to_csv.py
@@ -218,7 +218,91 @@ def _row_columns(tr: Node, headers: list[str], order: list[str]) -> dict[str, st
     return {order[i]: cells[i] for i in range(min(len(order), len(cells)))}
 
 
-def _extract_chintai_row(cols: dict[str, str]) -> dict[str, str]:
+def _row_cells(tr: Node) -> list[dict[str, str]]:
+    cells: list[dict[str, str]] = []
+    for td in tr.css("td"):
+        text = normalize_space(td.text(separator=" "))
+        label = normalize_space(
+            td.attributes.get("data-th")
+            or td.attributes.get("data-title")
+            or td.attributes.get("data-label")
+        ).replace(" ", "")
+        classes = normalize_space(td.attributes.get("class"))
+        cells.append({"text": text, "label": label, "class": classes})
+    return cells
+
+
+def _is_area_text(text: str) -> bool:
+    return bool(re.search(r"\d+(?:\.\d+)?\s*(?:㎡|m²|m2)", text))
+
+
+def _is_layout_text(text: str) -> bool:
+    return bool(
+        re.search(r"(?:\d+\s*(?:R|K|DK|LDK|SLDK)|ワンルーム|1R|1K|1DK|1LDK|2LDK|3LDK|4LDK)", text, re.IGNORECASE)
+    )
+
+
+def _is_floor_text(text: str) -> bool:
+    return bool(re.search(r"(?:所在階|[Bb]?\d+\s*(?:階|F))", text))
+
+
+def _is_direction_text(text: str) -> bool:
+    t = normalize_space(text)
+    if not t:
+        return False
+    if re.search(r"(北東|北西|南東|南西|東|西|南|北)(向き)?$", t):
+        return True
+    return "向き" in t and bool(re.search(r"(東|西|南|北)", t))
+
+
+def _is_tsubo_text(text: str) -> bool:
+    return "坪" in text and bool(re.search(r"(?:\d[\d,.]*\s*万?円?)", text))
+
+
+def _is_money_text(text: str) -> bool:
+    return bool(re.search(r"\d[\d,.]*(?:\.\d+)?\s*(?:万円|円)", text))
+
+
+def _is_deposit_or_key_text(text: str) -> bool:
+    t = normalize_space(text)
+    if not t:
+        return False
+    if any(token in t for token in ("なし", "無", "-")):
+        return True
+    if re.search(r"\d+(?:\.\d+)?\s*(?:ヶ月|か月)", t):
+        return True
+    return bool(re.search(r"\d[\d,.]*\s*円", t)) and "万円" not in t
+
+
+def _is_deco_cell(cell: dict[str, str], building_name: str) -> bool:
+    text = cell["text"]
+    label = cell["label"]
+    classes = cell["class"]
+    if not text:
+        return True
+    if "icon" in classes.lower():
+        return True
+    if text in {"新着", "リノベ", "リフォーム", "NEW"}:
+        return True
+    if "号室" in text:
+        return True
+    if building_name and normalize_space(building_name) == normalize_space(text):
+        return True
+    if not label and not _is_money_text(text) and not any(
+        (
+            _is_area_text(text),
+            _is_layout_text(text),
+            _is_floor_text(text),
+            _is_direction_text(text),
+            _is_tsubo_text(text),
+            _is_deposit_or_key_text(text),
+        )
+    ):
+        return True
+    return False
+
+
+def _extract_chintai_row(cols: dict[str, str], cells: list[dict[str, str]], building_name: str) -> dict[str, str]:
     rent = normalize_space(
         cols.get("賃料")
         or cols.get("賃料(管理費)")
@@ -240,24 +324,124 @@ def _extract_chintai_row(cols: dict[str, str]) -> dict[str, str]:
         deposit = parts[0]
         key_money = parts[1] if len(parts) > 1 else ""
 
+    area = normalize_space(cols.get("専有面積") or cols.get("面積"))
+    layout = normalize_space(cols.get("間取り"))
+
+    if rent and not _is_money_text(rent):
+        rent = ""
+    if fee and not (_is_money_text(fee) or fee in {"無料", "なし", "無", "-"}):
+        fee = ""
+    if deposit and not _is_deposit_or_key_text(deposit):
+        deposit = ""
+    if key_money and not _is_deposit_or_key_text(key_money):
+        key_money = ""
+    if area and not _is_area_text(area):
+        area = ""
+    if layout and not _is_layout_text(layout):
+        layout = ""
+
+    if not area or not layout:
+        data_cells = [c for c in cells if not _is_deco_cell(c, building_name)]
+        for cell in data_cells:
+            text = cell["text"]
+            label = cell["label"]
+            if not rent and (_is_money_text(text) and not any(k in text for k in ("管理費", "共益費", "敷", "礼"))):
+                rent = text
+                continue
+            if not fee and ("管理費" in label or "共益費" in label or "管理費" in text or "共益費" in text):
+                fee = text
+                continue
+            if (
+                not fee
+                and rent
+                and _is_money_text(text)
+                and not _is_tsubo_text(text)
+                and not any(k in text for k in ("敷", "礼"))
+                and not _is_area_text(text)
+            ):
+                fee = text
+                continue
+            if not deposit and ("敷" in label or "敷" in text):
+                deposit = text
+                continue
+            if not key_money and ("礼" in label or "礼" in text):
+                key_money = text
+                continue
+            if not deposit and _is_deposit_or_key_text(text):
+                deposit = text
+                continue
+            if not key_money and deposit and _is_deposit_or_key_text(text):
+                key_money = text
+                continue
+            if not area and _is_area_text(text):
+                area = text
+                continue
+            if not layout and _is_layout_text(text):
+                layout = text
+                continue
+
     return {
         "price_or_rent_text": rent,
         "fee_text": fee,
         "deposit_text": deposit,
         "key_money_text": key_money,
-        "area_text": normalize_space(cols.get("専有面積") or cols.get("面積")),
-        "layout_text": normalize_space(cols.get("間取り")),
+        "area_text": area,
+        "layout_text": layout,
     }
 
 
-def _extract_mansion_row(cols: dict[str, str]) -> dict[str, str]:
+def _extract_mansion_row(cols: dict[str, str], cells: list[dict[str, str]], building_name: str) -> dict[str, str]:
+    price = normalize_space(cols.get("価格") or cols.get("販売価格"))
+    tsubo = normalize_space(cols.get("坪単価"))
+    area = normalize_space(cols.get("専有面積") or cols.get("面積"))
+    layout = normalize_space(cols.get("間取り"))
+    floor = normalize_space(cols.get("所在階") or cols.get("階"))
+    direction = normalize_space(cols.get("向き") or cols.get("主要採光面"))
+
+    if price and (not _is_money_text(price) or _is_tsubo_text(price)):
+        price = ""
+    if tsubo and not _is_tsubo_text(tsubo):
+        tsubo = ""
+    if area and not _is_area_text(area):
+        area = ""
+    if layout and not _is_layout_text(layout):
+        layout = ""
+    if floor and not _is_floor_text(floor):
+        floor = ""
+    if direction and not _is_direction_text(direction):
+        direction = ""
+
+    if not all((price, tsubo, area, layout, floor, direction)):
+        data_cells = [c for c in cells if not _is_deco_cell(c, building_name)]
+        for cell in data_cells:
+            text = cell["text"]
+            label = cell["label"]
+            if not tsubo and ("坪単価" in label or _is_tsubo_text(text)):
+                tsubo = text
+                continue
+            if not area and ("面積" in label or _is_area_text(text)):
+                area = text
+                continue
+            if not layout and ("間取り" in label or _is_layout_text(text)):
+                layout = text
+                continue
+            if not floor and ("所在階" in label or _is_floor_text(text)):
+                floor = text
+                continue
+            if not direction and ("向き" in label or _is_direction_text(text)):
+                direction = text
+                continue
+            if not price and ("価格" in label or ("販売価格" in label) or (_is_money_text(text) and not _is_tsubo_text(text))):
+                price = text
+                continue
+
     return {
-        "price_or_rent_text": normalize_space(cols.get("価格") or cols.get("販売価格")),
-        "tsubo_unit_price_text": normalize_space(cols.get("坪単価")),
-        "area_text": normalize_space(cols.get("専有面積") or cols.get("面積")),
-        "layout_text": normalize_space(cols.get("間取り")),
-        "floor_text": normalize_space(cols.get("所在階") or cols.get("階")),
-        "direction_text": normalize_space(cols.get("向き") or cols.get("主要採光面")),
+        "price_or_rent_text": price,
+        "tsubo_unit_price_text": tsubo,
+        "area_text": area,
+        "layout_text": layout,
+        "floor_text": floor,
+        "direction_text": direction,
     }
 
 
@@ -279,12 +463,13 @@ def parse_list_page(html: str, page_url: str, kind: str, city_id: str, page_no: 
         headers = _table_headers(table)
         row_nodes = table.css("tbody.recommend_row tr")
         for tr in row_nodes:
+            cells = _row_cells(tr)
             cols = _row_columns(tr, headers, CHINTAI_ORDER if kind == "chintai" else MANSION_ORDER)
-            if not cols:
+            if not cols and not cells:
                 continue
 
             if kind == "chintai":
-                listing = _extract_chintai_row(cols)
+                listing = _extract_chintai_row(cols, cells, building_name)
                 rows.append(
                     ListRow(
                         kind=kind,
@@ -311,7 +496,7 @@ def parse_list_page(html: str, page_url: str, kind: str, city_id: str, page_no: 
                     )
                 )
             else:
-                sale = _extract_mansion_row(cols)
+                sale = _extract_mansion_row(cols, cells, building_name)
                 rows.append(
                     ListRow(
                         kind=kind,

--- a/tests/test_mansion_review_crawl_to_csv.py
+++ b/tests/test_mansion_review_crawl_to_csv.py
@@ -143,6 +143,37 @@ def test_parse_list_page_headerless_uses_fixed_column_order() -> None:
     assert rows[0].direction_text == "南西"
 
 
+def test_parse_list_page_mansion_ignores_leading_decorative_cells() -> None:
+    html = """
+    <html><body>
+      <article class="property-detail-list-item">
+        <h3>コクラタワー</h3>
+        <div class="property-detail-content_main"></div>
+        <table class="recommendTable"><tbody class="recommend_row">
+          <tr>
+            <td>新着</td><td>リノベ</td><td>コクラタワー</td><td>1302号室</td>
+            <td>3,180万円</td><td>159万円/坪</td><td>66.0㎡</td><td>2LDK</td><td>7階</td><td>南</td>
+          </tr>
+        </tbody></table>
+      </article>
+    </body></html>
+    """
+    rows, _ = parse_list_page(
+        html,
+        page_url="https://www.mansion-review.jp/mansion/city/1619.html",
+        kind="mansion",
+        city_id="1619",
+        page_no=1,
+    )
+    row = rows[0]
+    assert row.price_or_rent_text == "3,180万円"
+    assert row.tsubo_unit_price_text == "159万円/坪"
+    assert row.area_text == "66.0㎡"
+    assert row.layout_text == "2LDK"
+    assert row.floor_text == "7階"
+    assert row.direction_text == "南"
+
+
 def test_parse_list_page_chintai_combined_cells_are_split() -> None:
     html = """
     <html><body>
@@ -163,6 +194,37 @@ def test_parse_list_page_chintai_combined_cells_are_split() -> None:
             <td data-th="敷/礼">1ヶ月/2ヶ月</td>
             <td data-th="専有面積">45.1㎡</td>
             <td data-th="間取り">1LDK</td>
+          </tr>
+        </tbody></table>
+      </li>
+    </body></html>
+    """
+    rows, _ = parse_list_page(
+        html,
+        page_url="https://www.mansion-review.jp/chintai/city/1616.html",
+        kind="chintai",
+        city_id="1616",
+        page_no=1,
+    )
+    row = rows[0]
+    assert row.price_or_rent_text == "8.2万円"
+    assert row.fee_text == "6,000円"
+    assert row.deposit_text == "1ヶ月"
+    assert row.key_money_text == "2ヶ月"
+    assert row.area_text == "45.1㎡"
+    assert row.layout_text == "1LDK"
+
+
+def test_parse_list_page_chintai_ignores_leading_decorative_cells() -> None:
+    html = """
+    <html><body>
+      <li class="property-detail-list-item">
+        <h3>門司港レジデンス</h3>
+        <div class="property-detail-content_main"></div>
+        <table class="recommendTable"><tbody class="recommend_row">
+          <tr>
+            <td>新着</td><td>門司港レジデンス</td><td>203号室</td>
+            <td>8.2万円</td><td>6,000円</td><td>1ヶ月</td><td>2ヶ月</td><td>45.1㎡</td><td>1LDK</td>
           </tr>
         </tbody></table>
       </li>


### PR DESCRIPTION
### Motivation
- The recommendTable row extraction was producing column shifts when decorative/room-name/tag cells appeared on the left, causing listing fields to be placed in the wrong CSV columns; the change targets only that broken extraction logic.
- Keep the existing CSV outputs and ingest/render pipeline intact and avoid touching shared ingest/publish/render modules.

### Description
- Modified `scripts/mansion_review_crawl_to_csv.py` to build a per-`tr` cell model (`_row_cells`) and added semantic heuristics (`_is_area_text`, `_is_layout_text`, `_is_floor_text`, `_is_direction_text`, `_is_tsubo_text`, `_is_money_text`, `_is_deposit_or_key_text`) to detect field types from text when labels/headers are missing.
- Added `_is_deco_cell` to exclude leading decorative cells (e.g. `新着`, `リノベ`, room numbers, repeated building name, icon/empty cells) from data extraction so left-side decorations do not shift columns.
- Updated `_extract_chintai_row` and `_extract_mansion_row` to prefer header/label-driven values and fall back to meaning-based scans over non-decorative cells inside the row; adjusted `parse_list_page` to pass `cells` and `building_name` into these extractors.
- Tests updated: `tests/test_mansion_review_crawl_to_csv.py` adds regression cases that assert correct mapping for both 賃貸 and 分譲 when leading decorative cells are present; no other project files were modified.

### Testing
- Ran `pytest -q tests/test_mansion_review_crawl_to_csv.py` and it passed: `8 passed`.
- Ran `pytest -q tests/test_ingest_building_facts.py tests/test_master_import.py tests/test_build_smoke.py` and they passed: `16 passed` (ingest/render related smoke tests OK), confirming no regressions in downstream ingest/publish paths covered by those tests.
- Exercised the crawl CLI command `python scripts/mansion_review_crawl_to_csv.py --city-ids 1616,1619 --kinds chintai,mansion --max-pages 1 --sleep-sec 0 --out-dir tmp/manual/outputs/mansion_review_check --cache-dir tmp/manual/cache/mansion_review_check` but live fetch failed due to proxy/network restrictions (site returned connection error / tunnel 403), so end-to-end live verification on the real mansion-review.jp pages must be performed in a network-enabled environment.

Changed files: `scripts/mansion_review_crawl_to_csv.py`, `tests/test_mansion_review_crawl_to_csv.py`.

Remaining task: run the crawler in an environment with direct access to mansion-review.jp to confirm the produced `mansion_review_list.csv`, `building_facts.csv`, and `mansion_review_master_import.csv` against the live pages (1616/1619 chintai/mansion).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da140185f88326be69fd1f6237ee12)