### PR TITLE
mansion_review: 賃貸管理費分離の不具合修正と分譲 坪単価/向きの下流保持回帰

### DIFF
--- a/scripts/mansion_review_crawl_to_csv.py
+++ b/scripts/mansion_review_crawl_to_csv.py
@@ -621,7 +621,7 @@ def _split_chintai_rent_and_fee(price_or_rent_text: str, fee_text: str) -> tuple
         return rent_man, ""
 
     fee_raw = normalize_space(paren.group(1))
-    if not fee_raw or re.search(r"^-+\s*円?$", fee_raw):
+    if not fee_raw or re.search(r"^[\-ー−－]+\s*円?$", fee_raw) or fee_raw in {"なし", "無し"}:
         return rent_man, ""
     fee_from_paren = _extract_man_value(fee_raw)
     return rent_man, fee_from_paren

--- a/tests/test_building_registry.py
+++ b/tests/test_building_registry.py
@@ -205,7 +205,7 @@ def test_ingest_master_import_routes_mansion_to_sale_listings(tmp_path: Path) ->
     master_csv = tmp_path / "master_import_sale.csv"
     master_csv.write_text(
         "page,category,updated_at,building_name,room,address,rent_man,fee_man,floor,layout,area_sqm,availability_raw,built_raw,age_years,structure,built_year_month,built_age_years,availability_date,availability_flag_immediate,structure_raw,raw_block,evidence_id\n"
-        "1,mansion,2026/01/01 10:00,分譲テストマンション,701,福岡県北九州市小倉北区魚町1-1-1,3980,,7階,3LDK,72.5,,,,,2010-01,,,,,\"管理費:12000円 修繕積立金:8000円 坪単価:182万円/坪 向き:南\",e1\n",
+        "1,mansion,2026/01/01 10:00,分譲テストマンション,701,福岡県北九州市小倉北区魚町1-1-1,3980,,7階,3LDK,72.5,,,,,2010-01,,,,,\"管理費:12000円 | 修繕積立金:8000円 | 坪単価:182万円/坪 | 向き:南\",e1\n",
         encoding="utf-8",
     )
 

--- a/tests/test_mansion_review_crawl_to_csv.py
+++ b/tests/test_mansion_review_crawl_to_csv.py
@@ -334,3 +334,32 @@ def test_to_master_rows_sets_empty_fee_when_combined_text_has_hyphen_yen() -> No
     master = _to_master_rows([row], "2026/04/01 10:00")[0]
     assert master["rent_man"] == "10.8"
     assert master["fee_man"] == ""
+
+
+def test_to_master_rows_sets_empty_fee_when_combined_text_has_fullwidth_hyphen_yen() -> None:
+    row = ListRow(
+        kind="chintai",
+        city_id="1616",
+        ward="門司区",
+        city_page="1616_1",
+        page_url="https://www.mansion-review.jp/chintai/city/1616.html",
+        detail_url="https://www.mansion-review.jp/chintai/1",
+        building_name="テスト",
+        address="福岡県北九州市門司区1-1-1",
+        access_text="JR徒歩1分",
+        built_text="築10年",
+        building_floor_count_text="10階建",
+        total_units_text="30戸",
+        price_or_rent_text="10.8万円 (－円)",
+        fee_text="",
+        tsubo_unit_price_text="",
+        deposit_text="1ヶ月",
+        key_money_text="1ヶ月",
+        area_text="25.0㎡",
+        layout_text="1K",
+        floor_text="",
+        direction_text="",
+    )
+    master = _to_master_rows([row], "2026/04/01 10:00")[0]
+    assert master["rent_man"] == "10.8"
+    assert master["fee_man"] == ""


### PR DESCRIPTION
### Motivation
- 最小差分で Mansion Review の一覧由来データパイプラインについて、賃貸の `fee_man` 分離精度を高め、分譲の坪単価と向きが CSV→DB→summary→render まで消えないようにすること。 

### Description
- `scripts/mansion_review_crawl_to_csv.py` の `_split_chintai_rent_and_fee` を拡張して括弧内の管理費表記で全角/半角ハイフン類（`-`, `ー`, `−`, `－`）や `なし`/`無し` を「空の管理費」として扱うようにした。 
- `tests/test_mansion_review_crawl_to_csv.py` にフル幅ハイフンケースの回帰テスト `test_to_master_rows_sets_empty_fee_when_combined_text_has_fullwidth_hyphen_yen` を追加してパース結果を検証した。 
- `tests/test_building_registry.py` のテスト用 `raw_block` をクロール実運用に合わせて区切り文字に `|` を使う形に整え、分譲の `tsubo_unit_price_yen` と `direction_text` が ingest 経路で structured に保持されることを確認するように更新した。 
- 変更は上記スクリプトとテストのみで、指定の `ingest_building_facts.py` / `render/build.py` 等は触っていない。 

### Testing
- 集中的に実行した回帰テスト群（`tests/test_mansion_review_crawl_to_csv.py::test_to_master_rows_splits_chintai_rent_and_fee_from_combined_text`, `tests/test_mansion_review_crawl_to_csv.py::test_to_master_rows_sets_empty_fee_when_combined_text_has_hyphen_yen`, `tests/test_mansion_review_crawl_to_csv.py::test_to_master_rows_sets_empty_fee_when_combined_text_has_fullwidth_hyphen_yen`, `tests/test_building_registry.py::test_ingest_master_import_routes_mansion_to_sale_listings`, `tests/test_building_summaries.py::test_sale_summary_uses_sale_listings_payload`, `tests/test_render_dist.py::test_render_dist_sale_section_shows_tsubo_floor_and_direction`) はすべて成功（6 passed）。 
- フルスイート（`tests/test_mansion_review_crawl_to_csv.py`, `tests/test_building_registry.py`, `tests/test_building_summaries.py`, `tests/test_render_dist.py`）を実行したところ、今回の変更と無関係と思われる既存の2件の失敗が観測された: `test_render_dist_sanitizes_room_number_from_name_and_address` と `test_build_dist_versions_outputs_v2_min_json_with_contract`。 
- 変更済みの箇所に対する自動回帰は通っており、残課題として上記 2 件の既存失敗の切り分けが残る。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2a7d9b20832685a224ae9fc3b137)