### PR TITLE
Prefer mansion-review current facts and fix alias→canonical aggregation

### DIFF
--- a/src/tatemono_map/building_registry/ingest_building_facts.py
+++ b/src/tatemono_map/building_registry/ingest_building_facts.py
@@ -441,11 +441,14 @@ def ingest_building_facts_csv(
             should_repair_floor_count = False
             should_overwrite_access_info = False
             should_overwrite_floor_count = False
+            should_overwrite_built_year_month = False
+            should_overwrite_age_years = False
+            should_overwrite_total_units = False
             should_clear_stale_access_info = False
             should_clear_stale_floor_count = False
             if merge == "fill_only" and source == "mansion_review_list_facts":
                 existing_building = conn.execute(
-                    "SELECT access_info, floor_count_text FROM buildings WHERE building_id=?",
+                    "SELECT access_info, floor_count_text, built_year_month, age_years, total_units FROM buildings WHERE building_id=?",
                     (building_id,),
                 ).fetchone()
                 existing_access = existing_building["access_info"] if existing_building else None
@@ -459,6 +462,9 @@ def ingest_building_facts_csv(
 
                 should_overwrite_access_info = bool(access_info)
                 should_overwrite_floor_count = bool(floor_count_text)
+                should_overwrite_built_year_month = bool(built_year_month)
+                should_overwrite_age_years = age_years is not None
+                should_overwrite_total_units = total_units is not None and total_units > 0
                 should_clear_stale_access_info = (not access_info) and _is_invalid_access_info(existing_access)
                 should_clear_stale_floor_count = (not floor_count_text) and (not _is_valid_floor_count_text(existing_floor))
 
@@ -514,10 +520,14 @@ def ingest_building_facts_csv(
                             structure={_fill_only_sql('structure')},
                             age_years=CASE
                                 WHEN ? IS NOT NULL THEN ?
+                                WHEN ? THEN ?
                                 WHEN age_years IS NULL THEN ?
                                 ELSE age_years
                             END,
-                            built_year_month={_fill_only_sql('built_year_month')},
+                            built_year_month=CASE
+                                WHEN ? THEN ?
+                                ELSE {_fill_only_sql('built_year_month')}
+                            END,
                             property_kind={_fill_only_sql('property_kind')},
                             access_info=CASE
                                 WHEN ? THEN NULL
@@ -531,7 +541,11 @@ def ingest_building_facts_csv(
                                 WHEN floor_count_text IS NULL OR floor_count_text = '' OR ? THEN ?
                                 ELSE floor_count_text
                             END,
-                            total_units=CASE WHEN total_units IS NULL THEN ? ELSE total_units END,
+                            total_units=CASE
+                                WHEN ? THEN ?
+                                WHEN total_units IS NULL THEN ?
+                                ELSE total_units
+                            END,
                             management_style={_fill_only_sql('management_style')},
                             updated_at=CURRENT_TIMESTAMP
                         WHERE building_id=?
@@ -542,7 +556,11 @@ def ingest_building_facts_csv(
                             structure,
                             built_age_years,
                             built_age_years,
+                            should_overwrite_age_years,
                             age_years,
+                            age_years,
+                            should_overwrite_built_year_month,
+                            built_year_month,
                             built_year_month,
                             property_kind,
                             should_clear_stale_access_info,
@@ -555,6 +573,8 @@ def ingest_building_facts_csv(
                             floor_count_text,
                             should_repair_floor_count,
                             floor_count_text,
+                            should_overwrite_total_units,
+                            total_units,
                             total_units,
                             management_style,
                             building_id,
@@ -569,11 +589,15 @@ def ingest_building_facts_csv(
                             structure={_fill_only_sql('structure')},
                             age_years=CASE
                                 WHEN ? IS NOT NULL THEN ?
+                                WHEN ? THEN ?
                                 WHEN age_years IS NULL THEN ?
                                 ELSE age_years
                             END,
                             availability_label={_fill_only_sql('availability_label')},
-                            built_year_month={_fill_only_sql('built_year_month')},
+                            built_year_month=CASE
+                                WHEN ? THEN ?
+                                ELSE {_fill_only_sql('built_year_month')}
+                            END,
                             property_kind={_fill_only_sql('property_kind')},
                             sale_price_yen_min=CASE WHEN sale_price_yen_min IS NULL THEN ? ELSE sale_price_yen_min END,
                             sale_price_yen_max=CASE WHEN sale_price_yen_max IS NULL THEN ? ELSE sale_price_yen_max END,
@@ -596,14 +620,28 @@ def ingest_building_facts_csv(
                                 WHEN floor_count_text IS NULL OR floor_count_text = '' OR ? THEN ?
                                 ELSE floor_count_text
                             END,
-                            total_units=CASE WHEN total_units IS NULL THEN ? ELSE total_units END,
+                            total_units=CASE
+                                WHEN ? THEN ?
+                                WHEN total_units IS NULL THEN ?
+                                ELSE total_units
+                            END,
                             management_style={_fill_only_sql('management_style')},
                             updated_at=CURRENT_TIMESTAMP
                         WHERE building_id=?
                         """,
                         (
                             normalized.raw_name, normalized.canonical_address,
-                            structure, built_age_years, built_age_years, age_years, availability_label, built_year_month, property_kind,
+                            structure,
+                            built_age_years,
+                            built_age_years,
+                            should_overwrite_age_years,
+                            age_years,
+                            age_years,
+                            availability_label,
+                            should_overwrite_built_year_month,
+                            built_year_month,
+                            built_year_month,
+                            property_kind,
                             sale_price_yen_min, sale_price_yen_max, sale_price_yen_avg,
                             sale_area_sqm_min, sale_area_sqm_max, sale_layout_types_json,
                             sale_listing_count,
@@ -619,6 +657,8 @@ def ingest_building_facts_csv(
                             floor_count_text,
                             should_repair_floor_count,
                             floor_count_text,
+                            should_overwrite_total_units,
+                            total_units,
                             total_units,
                             management_style,
                             building_id,

--- a/src/tatemono_map/normalize/building_summaries.py
+++ b/src/tatemono_map/normalize/building_summaries.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from collections import Counter
 from datetime import date
 
@@ -48,6 +49,39 @@ def _pick_built_year_month(values: list[str]) -> str | None:
     max_count = max(counts.values())
     modes = sorted(value for value, count in counts.items() if count == max_count)
     return modes[0]
+
+
+def _is_valid_access_info(value: str | None) -> bool:
+    cleaned = normalize_text(value)
+    if not cleaned:
+        return False
+    if "線" in cleaned and "駅" not in cleaned:
+        return False
+    return any(token in cleaned for token in ("駅", "徒歩", "バス"))
+
+
+def _is_valid_floor_count_text(value: str | None) -> bool:
+    cleaned = normalize_text(value)
+    if not cleaned:
+        return False
+    if "て:" in cleaned or "階建て:" in cleaned:
+        return False
+    return re.fullmatch(r"(地上\d+階建|地上\d+階建\s*地下\d+階|地下\d+階\s*地上\d+階建)", cleaned) is not None
+
+
+def _pick_latest_valid_value(rows: list[dict], field: str, *, validator=None):
+    for row in sorted(rows, key=lambda r: (normalize_text(r.get("updated_at")) or "", str(r.get("building_id") or "")), reverse=True):
+        value = row.get(field)
+        if value is None:
+            continue
+        if isinstance(value, str):
+            value = normalize_text(value)
+            if not value:
+                continue
+        if validator and not validator(value):
+            continue
+        return value
+    return None
 
 
 def _nearest_availability_date(items: list) -> str | None:
@@ -131,7 +165,8 @@ def rebuild(db_path: str) -> int:
                structure, age_years, built_year, built_year_month, availability_raw, availability_label,
                property_kind, sale_price_yen_min, sale_price_yen_max, sale_price_yen_avg,
                sale_area_sqm_min, sale_area_sqm_max, sale_layout_types_json, sale_listing_count,
-               avg_rent_yen, rental_listing_count, management_style, floor_count_text, total_units
+               avg_rent_yen, rental_listing_count, management_style, floor_count_text, total_units,
+               access_info, updated_at
         FROM buildings
         """
     ).fetchall()
@@ -182,7 +217,27 @@ def rebuild(db_path: str) -> int:
         canonical_key = alias_map.get(row["building_key"], row["building_key"])
         grouped_sale.setdefault(canonical_key, []).append(row)
 
-    canonical_by_id = {row["building_id"]: row for row in building_rows}
+    building_dicts = [dict(row) for row in building_rows]
+    canonical_by_id = {row["building_id"]: row for row in building_dicts}
+    grouped_buildings: dict[str, list[dict]] = {key: [row] for key, row in canonical_by_id.items()}
+    for alias_key, canonical_key in alias_map.items():
+        alias_row = canonical_by_id.get(alias_key)
+        if not alias_row:
+            continue
+        grouped_buildings.setdefault(canonical_key, [])
+        if all(existing["building_id"] != alias_key for existing in grouped_buildings[canonical_key]):
+            grouped_buildings[canonical_key].append(alias_row)
+    merged_canonical_by_id: dict[str, dict] = {}
+    for building_id, base in canonical_by_id.items():
+        merged = dict(base)
+        candidates = grouped_buildings.get(building_id, [base])
+        merged["access_info"] = _pick_latest_valid_value(candidates, "access_info", validator=_is_valid_access_info) or merged.get("access_info")
+        merged["floor_count_text"] = _pick_latest_valid_value(candidates, "floor_count_text", validator=_is_valid_floor_count_text) or merged.get("floor_count_text")
+        merged["total_units"] = _pick_latest_valid_value(candidates, "total_units", validator=lambda v: isinstance(v, int) and v > 0) or merged.get("total_units")
+        merged["built_year_month"] = _pick_latest_valid_value(candidates, "built_year_month") or merged.get("built_year_month")
+        merged["age_years"] = _pick_latest_valid_value(candidates, "age_years", validator=lambda v: isinstance(v, int) and v >= 0) or merged.get("age_years")
+        merged_canonical_by_id[building_id] = merged
+
     target_keys = set(canonical_by_id.keys()) | set(grouped.keys()) | set(grouped_sale.keys())
 
     for building_key in sorted(target_keys):
@@ -194,7 +249,7 @@ def rebuild(db_path: str) -> int:
             if available_ranks and len(ranked_items) == len(items):
                 best_rank = min(available_ranks)
                 items = [row for row in items if rental_priority.get(str(row["source_kind"])) == best_rank]
-        building = canonical_by_id.get(building_key)
+        building = merged_canonical_by_id.get(building_key)
         rents = [r["rent_yen"] for r in items if r["rent_yen"] is not None]
         maints = [r["maint_yen"] for r in items if r["maint_yen"] is not None]
         areas = [r["area_sqm"] for r in items if r["area_sqm"] is not None]

--- a/src/tatemono_map/render/build.py
+++ b/src/tatemono_map/render/build.py
@@ -916,11 +916,35 @@ def _load_buildings(db_path: str) -> tuple[list[dict], int, int, int, int]:
         floor_text = str(row["floor_text"] or "").strip()
         if floor_text and floor_text not in current["floors"]:
             current["floors"].append(floor_text)
-    for alias_key, canonical_key in alias_map.items():
-        if alias_key in rental_summary_map and canonical_key not in rental_summary_map:
-            rental_summary_map[canonical_key] = rental_summary_map[alias_key]
-        if alias_key in sale_summary_map and canonical_key not in sale_summary_map:
-            sale_summary_map[canonical_key] = sale_summary_map[alias_key]
+    merged_rental_summary_map: dict[str, dict] = {}
+    for key, row in rental_summary_map.items():
+        canonical_key = alias_map.get(key, key)
+        current = merged_rental_summary_map.get(canonical_key)
+        if current is None:
+            merged_rental_summary_map[canonical_key] = dict(row)
+            continue
+        current_updated = str(current.get("updated_at") or "")
+        row_updated = str(row.get("updated_at") or "")
+        current_count = int(current.get("vacancy_count") or 0)
+        row_count = int(row.get("vacancy_count") or 0)
+        if (row_count, row_updated) > (current_count, current_updated):
+            merged_rental_summary_map[canonical_key] = dict(row)
+    rental_summary_map = merged_rental_summary_map
+
+    merged_sale_summary_map: dict[str, dict] = {}
+    for key, row in sale_summary_map.items():
+        canonical_key = alias_map.get(key, key)
+        current = merged_sale_summary_map.get(canonical_key)
+        if current is None:
+            merged_sale_summary_map[canonical_key] = dict(row)
+            continue
+        current_updated = str(current.get("updated_at") or "")
+        row_updated = str(row.get("updated_at") or "")
+        current_count = int(current.get("sale_listing_count") or 0)
+        row_count = int(row.get("sale_listing_count") or 0)
+        if (row_count, row_updated) > (current_count, current_updated):
+            merged_sale_summary_map[canonical_key] = dict(row)
+    sale_summary_map = merged_sale_summary_map
     conn.close()
     for building in building_list:
         building["sponsor"] = sponsor_map.get(str(building.get("building_key")))


### PR DESCRIPTION
### Motivation
- Canonical building pages were showing stale or broken values because current Mansion Review facts lived on alias keys and were not reliably aggregated to canonical keys.
- The goal is to ensure current `mansion_review` data overwrites old garbage for key building facts and that rental/sale summaries from alias keys propagate to canonical pages.

### Description
- Allow `mansion_review_list_facts` ingestion in `fill_only` mode to overwrite stale canonical fields by adding overwrite flags for `built_year_month`, `age_years`, and `total_units` and wiring them into the `UPDATE` logic in `src/tatemono_map/building_registry/ingest_building_facts.py`.
- When rebuilding summaries in `src/tatemono_map/normalize/building_summaries.py`, merge canonical + alias building rows and pick latest/validated values for `access_info`, `floor_count_text`, `total_units`, `built_year_month`, and `age_years` using new validators and a `_pick_latest_valid_value` helper.
- In render path `src/tatemono_map/render/build.py`, re-aggregate `building_rental_summaries` and `building_sale_summaries` into canonical keys by resolving aliases for every summary row and selecting the richer/newer row using `(listing_count, updated_at)` as a tie-breaker so alias summaries no longer get lost.
- Minor input validation: added simple validators to reject noisy/invalid `access_info` and `floor_count_text` (e.g. "て:", missing station name, or route-only values) before preferring them over canonical values.

### Testing
- Successfully ran `python -m py_compile src/tatemono_map/normalize/building_summaries.py src/tatemono_map/render/build.py src/tatemono_map/building_registry/ingest_building_facts.py` with no syntax errors.
- Ran unit tests with `PYTHONPATH=. pytest -q tests/test_import_building_master.py tests/test_schema_migration.py tests/test_schema_reproducibility_pipeline.py` which passed: `9 passed`.
- Note: running `pytest -q` without `PYTHONPATH=.` in this environment raised `ModuleNotFoundError: tests` due to test import path; this is an environment/runner issue and not a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa0fd5b1c832695c545580320aa98)