### PR TITLE
UI: reorder rental/sale/building cards into 2-column layout without visible headings

### DIFF
--- a/templates/building.html.j2
+++ b/templates/building.html.j2
@@ -57,6 +57,26 @@
     display: grid;
     gap: 8px;
   }
+  .a11y-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .fact-row {
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+  .fact-row--single {
+    grid-template-columns: minmax(0, 1fr);
+  }
 
   .fact {
     margin: 0;
@@ -66,11 +86,11 @@
     border-top: 1px dashed var(--border);
     padding-top: 8px;
   }
-
-  .fact:first-child {
+  .fact-row:first-child .fact {
     border-top: 0;
     padding-top: 0;
   }
+  .fact--wide { grid-column: 1 / -1; }
 
   .fact dt {
     color: var(--muted);
@@ -116,6 +136,9 @@
   .mode-panel[hidden] { display: none; }
 
   @media (max-width: 740px) {
+    .fact-row {
+      grid-template-columns: minmax(0, 1fr);
+    }
     .fact {
       grid-template-columns: 1fr;
       gap: 4px;
@@ -173,83 +196,88 @@
 
     {% if show_sale %}
     <section class="info card mode-panel" aria-label="売出し情報" data-mode-panel="sale" {% if is_both_mode %}hidden{% endif %}>
-      <h2>売出し情報</h2>
+      <h2 class="a11y-only">売出し情報</h2>
       <dl class="facts">
-        <div class="fact">
-          <dt>販売状況</dt>
-          <dd>{{ building.sale_status_label }}</dd>
+        <div class="fact-row{% if not ((building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0) %} fact-row--single{% endif %}">
+          <div class="fact">
+            <dt>販売状況</dt>
+            <dd>{{ building.sale_status_label }}</dd>
+          </div>
+          {% if (building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0 %}
+          <div class="fact">
+            <dt>価格</dt>
+            <dd>{{ building.sale_price_label or "販売中" }}</dd>
+          </div>
+          {% endif %}
         </div>
         {% if (building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0 %}
-        <div class="fact">
-          <dt>価格</dt>
-          <dd>{{ building.sale_price_label or "販売中" }}</dd>
+        <div class="fact-row{% if not (building.sale_floor_label and building.sale_direction_label) %} fact-row--single{% endif %}">
+          {% if building.sale_floor_label %}<div class="fact"><dt>所在階</dt><dd>{{ building.sale_floor_label }}</dd></div>{% endif %}
+          {% if building.sale_direction_label %}<div class="fact"><dt>向き</dt><dd>{{ building.sale_direction_label }}</dd></div>{% endif %}
         </div>
-        <div class="fact">
-          <dt>間取り</dt>
-          <dd>{{ building.sale_layout_label or "要確認" }}</dd>
+        <div class="fact-row">
+          <div class="fact"><dt>間取り</dt><dd>{{ building.sale_layout_label or "要確認" }}</dd></div>
+          <div class="fact"><dt>面積</dt><dd>{{ building.sale_area_label or "要確認" }}</dd></div>
         </div>
-        <div class="fact">
-          <dt>面積</dt>
-          <dd>{{ building.sale_area_label or "要確認" }}</dd>
-        </div>
-        {% if building.sale_sqm_price_label %}<div class="fact"><dt>㎡単価</dt><dd>{{ building.sale_sqm_price_label }}</dd></div>{% endif %}
-        {% if building.sale_floor_label %}<div class="fact"><dt>所在階</dt><dd>{{ building.sale_floor_label }}</dd></div>{% endif %}
-        {% if building.sale_direction_label %}<div class="fact"><dt>向き</dt><dd>{{ building.sale_direction_label }}</dd></div>{% endif %}
-        {% if building.sale_summary and (building.sale_summary.management_fee_yen_min or building.sale_summary.management_fee_yen_max) %}
-        <div class="fact">
-          <dt>管理費</dt>
-          <dd>{{ (building.sale_summary.management_fee_yen_min|yen ~ "円/月") if building.sale_summary.management_fee_yen_min == building.sale_summary.management_fee_yen_max else (building.sale_summary.management_fee_yen_min|yen ~ "円/月〜" ~ building.sale_summary.management_fee_yen_max|yen ~ "円/月") }}</dd>
-        </div>
-        {% endif %}
-        {% if building.sale_summary and (building.sale_summary.repair_fund_yen_min or building.sale_summary.repair_fund_yen_max) %}
-        <div class="fact">
-          <dt>修繕積立金</dt>
-          <dd>{{ (building.sale_summary.repair_fund_yen_min|yen ~ "円/月") if building.sale_summary.repair_fund_yen_min == building.sale_summary.repair_fund_yen_max else (building.sale_summary.repair_fund_yen_min|yen ~ "円/月〜" ~ building.sale_summary.repair_fund_yen_max|yen ~ "円/月") }}</dd>
-        </div>
-        {% endif %}
+        {% if building.sale_sqm_price_label %}<div class="fact-row fact-row--single"><div class="fact fact--wide"><dt>㎡単価</dt><dd>{{ building.sale_sqm_price_label }}</dd></div></div>{% endif %}
         {% endif %}
       </dl>
     </section>
 
     <section class="info card" aria-label="建物概要">
-      <h2>建物概要</h2>
+      <h2 class="a11y-only">建物概要</h2>
       <dl class="facts">
+        <div class="fact-row{% if not (building.built_label and building.display_structure) %} fact-row--single{% endif %}">
         {% if building.built_label %}<div class="fact"><dt>築年月</dt><dd>{{ building.built_label }}</dd></div>{% endif %}
         {% if building.display_structure %}<div class="fact"><dt>構造</dt><dd>{{ building.display_structure }}</dd></div>{% endif %}
+        </div>
         {% set floor_count_text = (building.sale_summary.floor_count_text if building.sale_summary and building.sale_summary.floor_count_text else building.floor_count_text) %}
-        {% if floor_count_text %}<div class="fact"><dt>階建て</dt><dd>{{ floor_count_text }}</dd></div>{% endif %}
         {% set total_units = (building.sale_summary.total_units if building.sale_summary and building.sale_summary.total_units else building.total_units) %}
+        <div class="fact-row{% if not (floor_count_text and total_units) %} fact-row--single{% endif %}">
+        {% if floor_count_text %}<div class="fact"><dt>階建て</dt><dd>{{ floor_count_text }}</dd></div>{% endif %}
         {% if total_units %}<div class="fact"><dt>総戸数</dt><dd>{{ total_units }}</dd></div>{% endif %}
-        {% if building.access_info %}<div class="fact"><dt>交通</dt><dd>{{ building.access_info }}</dd></div>{% endif %}
-        {% set management_style = (building.sale_summary.management_style if building.sale_summary and building.sale_summary.management_style else building.management_style) %}
-        {% if management_style %}<div class="fact"><dt>管理方式</dt><dd>{{ management_style }}</dd></div>{% endif %}
+        </div>
+        {% if building.access_info %}<div class="fact-row fact-row--single"><div class="fact fact--wide"><dt>交通</dt><dd>{{ building.access_info }}</dd></div></div>{% endif %}
       </dl>
     </section>
     {% endif %}
     {% if show_rental %}
     <section class="info card mode-panel" aria-label="募集情報" data-mode-panel="rental">
-      <h2>募集情報</h2>
+      <h2 class="a11y-only">募集情報</h2>
       <dl class="facts">
-        <div class="fact"><dt>空室</dt><dd>{{ building.rental_vacancy_label }}</dd></div>
+        <div class="fact-row{% if not ((building.vacancy_count or 0) > 0 and building.rental_rent_label) %} fact-row--single{% endif %}">
+          <div class="fact"><dt>空室</dt><dd>{{ building.rental_vacancy_label }}</dd></div>
+          {% if (building.vacancy_count or 0) > 0 and building.rental_rent_label %}<div class="fact"><dt>賃料</dt><dd>{{ building.rental_rent_label }}</dd></div>{% endif %}
+        </div>
         {% if (building.vacancy_count or 0) > 0 %}
-        {% if building.rental_rent_label %}<div class="fact"><dt>賃料</dt><dd>{{ building.rental_rent_label }}</dd></div>{% endif %}
-        {% if building.rental_maint_label %}<div class="fact"><dt>管理費 / 共益費</dt><dd>{{ building.rental_maint_label }}</dd></div>{% endif %}
-        {% if building.rental_deposit_label %}<div class="fact"><dt>敷金</dt><dd>{{ building.rental_deposit_label }}</dd></div>{% endif %}
-        {% if building.rental_key_money_label %}<div class="fact"><dt>礼金</dt><dd>{{ building.rental_key_money_label }}</dd></div>{% endif %}
-        {% if building.rental_layout_label %}<div class="fact"><dt>間取り</dt><dd>{{ building.rental_layout_label }}</dd></div>{% endif %}
-        {% if building.rental_area_label %}<div class="fact"><dt>面積</dt><dd>{{ building.rental_area_label }}</dd></div>{% endif %}
-        {% if building.rental_floor_label %}<div class="fact"><dt>所在階</dt><dd>{{ building.rental_floor_label }}</dd></div>{% endif %}
-        {% if building.rental_move_in_label %}<div class="fact"><dt>入居可能日</dt><dd>{{ "即入居あり" if building.rental_move_in_label == "入居" else building.rental_move_in_label }}</dd></div>{% endif %}
-        {% else %}
-        <div class="fact"><dt>補足</dt><dd>現在、この建物の募集は確認できていません。ご希望に近いお部屋もご案内可能です。</dd></div>
+        <div class="fact-row{% if not (building.rental_move_in_label and building.rental_maint_label) %} fact-row--single{% endif %}">
+          {% if building.rental_move_in_label %}<div class="fact"><dt>入居可能日</dt><dd>{{ "即入居あり" if building.rental_move_in_label == "入居" else building.rental_move_in_label }}</dd></div>{% endif %}
+          {% if building.rental_maint_label %}<div class="fact"><dt>管理費・共益費</dt><dd>{{ building.rental_maint_label }}</dd></div>{% endif %}
+        </div>
+        <div class="fact-row{% if not (building.rental_layout_label and building.rental_area_label) %} fact-row--single{% endif %}">
+          {% if building.rental_layout_label %}<div class="fact"><dt>間取り</dt><dd>{{ building.rental_layout_label }}</dd></div>{% endif %}
+          {% if building.rental_area_label %}<div class="fact"><dt>面積</dt><dd>{{ building.rental_area_label }}</dd></div>{% endif %}
+        </div>
+        {% if building.rental_deposit_label or building.rental_key_money_label %}
+        <div class="fact-row{% if not (building.rental_deposit_label and building.rental_key_money_label) %} fact-row--single{% endif %}">
+          {% if building.rental_deposit_label %}<div class="fact"><dt>敷金</dt><dd>{{ building.rental_deposit_label }}</dd></div>{% endif %}
+          {% if building.rental_key_money_label %}<div class="fact"><dt>礼金</dt><dd>{{ building.rental_key_money_label }}</dd></div>{% endif %}
+        </div>
         {% endif %}
+        {% else %}
+        <div class="fact-row fact-row--single"><div class="fact fact--wide"><dt>補足</dt><dd>現在、この建物の募集は確認できていません。ご希望に近いお部屋もご案内可能です。</dd></div></div>
+        {% endif %}
+      <div class="fact-row{% if not (building.built_label and building.display_structure) %} fact-row--single{% endif %}">
       {% if building.built_label %}<div class="fact"><dt>築年月</dt><dd>{{ building.built_label }}</dd></div>{% endif %}
       {% if building.display_structure %}<div class="fact"><dt>構造</dt><dd>{{ building.display_structure }}</dd></div>{% endif %}
+      </div>
       {% set floor_count_text = (building.sale_summary.floor_count_text if building.sale_summary and building.sale_summary.floor_count_text else building.floor_count_text) %}
-      {% if floor_count_text %}<div class="fact"><dt>階建て</dt><dd>{{ floor_count_text }}</dd></div>{% endif %}
       {% set total_units = (building.sale_summary.total_units if building.sale_summary and building.sale_summary.total_units else building.total_units) %}
+      <div class="fact-row{% if not (floor_count_text and total_units) %} fact-row--single{% endif %}">
+      {% if floor_count_text %}<div class="fact"><dt>階建て</dt><dd>{{ floor_count_text }}</dd></div>{% endif %}
       {% if total_units %}<div class="fact"><dt>総戸数</dt><dd>{{ total_units }}</dd></div>{% endif %}
-      {% if building.access_info %}<div class="fact"><dt>交通</dt><dd>{{ building.access_info }}</dd></div>{% endif %}
+      </div>
+      {% if building.access_info %}<div class="fact-row fact-row--single"><div class="fact fact--wide"><dt>交通</dt><dd>{{ building.access_info }}</dd></div></div>{% endif %}
       </dl>
     </section>
     {% endif %}

--- a/templates_v2/building.html.j2
+++ b/templates_v2/building.html.j2
@@ -14,9 +14,23 @@
   .breadcrumb a:hover { text-decoration: underline; }
   .hero, .map-embed, .info, .line-cta { padding: clamp(16px, 2.5vw, 24px); }
   .hero p { margin: 8px 0 0; color: var(--muted); }
+  .a11y-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
   .facts { margin: 0; display: grid; gap: 10px; }
+  .fact-row { margin: 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+  .fact-row--single { grid-template-columns: minmax(0, 1fr); }
   .fact { margin: 0; display: grid; grid-template-columns: 128px minmax(0,1fr); border-top: 1px solid var(--border-soft); padding-top: 9px; }
-  .fact:first-child { border-top: 0; padding-top: 0; }
+  .fact-row:first-child .fact { border-top: 0; padding-top: 0; }
+  .fact--wide { grid-column: 1 / -1; }
   .fact dt { color: var(--muted); }
   .fact dd { margin: 0; font-weight: 600; }
   .line-cta {
@@ -44,6 +58,7 @@
     .map-embed-frame { height: 340px; }
   }
   @media (max-width: 740px) {
+    .fact-row { grid-template-columns: minmax(0, 1fr); }
     .fact { grid-template-columns: 1fr; gap: 2px; }
     .line-cta .button { max-width: none; width: 100%; }
   }
@@ -97,34 +112,50 @@
 
   {% if show_sale %}
   <section class="info card mode-panel" aria-label="販売状況" data-mode-panel="sale" {% if is_both_mode %}hidden{% endif %}>
-    <h2>販売状況</h2>
+    <h2 class="a11y-only">販売状況</h2>
     <dl class="facts">
-      <div class="fact"><dt>販売状況</dt><dd>{{ building.sale_status_label }}</dd></div>
+      <div class="fact-row{% if not ((building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0) %} fact-row--single{% endif %}">
+        <div class="fact"><dt>販売状況</dt><dd>{{ building.sale_status_label }}</dd></div>
+        {% if (building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0 %}
+        <div class="fact"><dt>価格</dt><dd>{{ building.sale_price_label or "販売中" }}</dd></div>
+        {% endif %}
+      </div>
       {% if (building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0 %}
-      <div class="fact"><dt>価格</dt><dd>{{ building.sale_price_label or "販売中" }}</dd></div>
-      <div class="fact"><dt>間取り</dt><dd>{{ building.sale_layout_label or "要確認" }}</dd></div>
-      <div class="fact"><dt>面積</dt><dd>{{ building.sale_area_label or "要確認" }}</dd></div>
-      {% if building.sale_sqm_price_label %}<div class="fact"><dt>㎡単価</dt><dd>{{ building.sale_sqm_price_label }}</dd></div>{% endif %}
-      {% if building.sale_floor_label %}<div class="fact"><dt>所在階</dt><dd>{{ building.sale_floor_label }}</dd></div>{% endif %}
-      {% if building.sale_direction_label %}<div class="fact"><dt>向き</dt><dd>{{ building.sale_direction_label }}</dd></div>{% endif %}
-      {% if building.sale_summary and (building.sale_summary.management_fee_yen_min or building.sale_summary.management_fee_yen_max) %}<div class="fact"><dt>管理費</dt><dd>{{ (building.sale_summary.management_fee_yen_min|yen ~ "円/月") if building.sale_summary.management_fee_yen_min == building.sale_summary.management_fee_yen_max else (building.sale_summary.management_fee_yen_min|yen ~ "円/月〜" ~ building.sale_summary.management_fee_yen_max|yen ~ "円/月") }}</dd></div>{% endif %}
-      {% if building.sale_summary and (building.sale_summary.repair_fund_yen_min or building.sale_summary.repair_fund_yen_max) %}<div class="fact"><dt>修繕積立金</dt><dd>{{ (building.sale_summary.repair_fund_yen_min|yen ~ "円/月") if building.sale_summary.repair_fund_yen_min == building.sale_summary.repair_fund_yen_max else (building.sale_summary.repair_fund_yen_min|yen ~ "円/月〜" ~ building.sale_summary.repair_fund_yen_max|yen ~ "円/月") }}</dd></div>{% endif %}
+      <div class="fact-row{% if not (building.sale_floor_label and building.sale_direction_label) %} fact-row--single{% endif %}">
+        {% if building.sale_floor_label %}
+        <div class="fact"><dt>所在階</dt><dd>{{ building.sale_floor_label }}</dd></div>
+        {% endif %}
+        {% if building.sale_direction_label %}
+        <div class="fact"><dt>向き</dt><dd>{{ building.sale_direction_label }}</dd></div>
+        {% endif %}
+      </div>
+      <div class="fact-row">
+        <div class="fact"><dt>間取り</dt><dd>{{ building.sale_layout_label or "要確認" }}</dd></div>
+        <div class="fact"><dt>面積</dt><dd>{{ building.sale_area_label or "要確認" }}</dd></div>
+      </div>
+      {% if building.sale_sqm_price_label %}
+      <div class="fact-row fact-row--single">
+        <div class="fact fact--wide"><dt>㎡単価</dt><dd>{{ building.sale_sqm_price_label }}</dd></div>
+      </div>
+      {% endif %}
       {% endif %}
     </dl>
   </section>
 
   <section class="info card{% if is_both_mode %} mode-panel{% endif %}" aria-label="建物概要" {% if is_both_mode %}data-mode-panel="sale" hidden{% endif %}>
-    <h2>建物概要</h2>
+    <h2 class="a11y-only">建物概要</h2>
     <dl class="facts">
+      <div class="fact-row{% if not (building.built_label and building.display_structure) %} fact-row--single{% endif %}">
       {% if building.built_label %}<div class="fact"><dt>築年月</dt><dd>{{ building.built_label }}</dd></div>{% endif %}
       {% if building.display_structure %}<div class="fact"><dt>構造</dt><dd>{{ building.display_structure }}</dd></div>{% endif %}
+      </div>
       {% set floor_count_text = (building.sale_summary.floor_count_text if building.sale_summary and building.sale_summary.floor_count_text else building.floor_count_text) %}
-      {% if floor_count_text %}<div class="fact"><dt>階建て</dt><dd>{{ floor_count_text }}</dd></div>{% endif %}
       {% set total_units = (building.sale_summary.total_units if building.sale_summary and building.sale_summary.total_units else building.total_units) %}
+      <div class="fact-row{% if not (floor_count_text and total_units) %} fact-row--single{% endif %}">
+      {% if floor_count_text %}<div class="fact"><dt>階建て</dt><dd>{{ floor_count_text }}</dd></div>{% endif %}
       {% if total_units %}<div class="fact"><dt>総戸数</dt><dd>{{ total_units }}</dd></div>{% endif %}
-      {% if building.access_info %}<div class="fact"><dt>交通</dt><dd>{{ building.access_info }}</dd></div>{% endif %}
-      {% set management_style = (building.sale_summary.management_style if building.sale_summary and building.sale_summary.management_style else building.management_style) %}
-      {% if management_style %}<div class="fact"><dt>管理方式</dt><dd>{{ management_style }}</dd></div>{% endif %}
+      </div>
+      {% if building.access_info %}<div class="fact-row fact-row--single"><div class="fact fact--wide"><dt>交通</dt><dd>{{ building.access_info }}</dd></div></div>{% endif %}
     </dl>
   </section>
 
@@ -150,34 +181,47 @@
   {% endif %}
   {% if show_rental %}
   <section class="info card mode-panel" aria-label="募集情報" data-mode-panel="rental">
-    <h2>募集情報</h2>
+    <h2 class="a11y-only">募集情報</h2>
     <dl class="facts">
-      <div class="fact"><dt>空室</dt><dd>{{ building.rental_vacancy_label }}</dd></div>
+      <div class="fact-row{% if not ((building.vacancy_count or 0) > 0 and building.rental_rent_label) %} fact-row--single{% endif %}">
+        <div class="fact"><dt>空室</dt><dd>{{ building.rental_vacancy_label }}</dd></div>
+        {% if (building.vacancy_count or 0) > 0 and building.rental_rent_label %}<div class="fact"><dt>賃料</dt><dd>{{ building.rental_rent_label }}</dd></div>{% endif %}
+      </div>
       {% if (building.vacancy_count or 0) > 0 %}
-      {% if building.rental_rent_label %}<div class="fact"><dt>賃料</dt><dd>{{ building.rental_rent_label }}</dd></div>{% endif %}
+      <div class="fact-row{% if not (building.rental_move_in_label and building.rental_maint_label) %} fact-row--single{% endif %}">
+      {% if building.rental_move_in_label %}<div class="fact"><dt>入居可能日</dt><dd>{{ "即入居" if building.rental_move_in_label == "入居" else building.rental_move_in_label }}</dd></div>{% endif %}
       {% if building.rental_maint_label %}<div class="fact"><dt>管理費・共益費</dt><dd>{{ building.rental_maint_label }}</dd></div>{% endif %}
-      {% if building.rental_deposit_label %}<div class="fact"><dt>敷金</dt><dd>{{ building.rental_deposit_label }}</dd></div>{% endif %}
-      {% if building.rental_key_money_label %}<div class="fact"><dt>礼金</dt><dd>{{ building.rental_key_money_label }}</dd></div>{% endif %}
+      </div>
+      <div class="fact-row{% if not (building.rental_layout_label and building.rental_area_label) %} fact-row--single{% endif %}">
       {% if building.rental_layout_label %}<div class="fact"><dt>間取り</dt><dd>{{ building.rental_layout_label }}</dd></div>{% endif %}
       {% if building.rental_area_label %}<div class="fact"><dt>面積</dt><dd>{{ building.rental_area_label }}</dd></div>{% endif %}
-      {% if building.rental_floor_label %}<div class="fact"><dt>所在階</dt><dd>{{ building.rental_floor_label }}</dd></div>{% endif %}
-      {% if building.rental_move_in_label %}<div class="fact"><dt>入居可能日</dt><dd>{{ "即入居" if building.rental_move_in_label == "入居" else building.rental_move_in_label }}</dd></div>{% endif %}
+      </div>
+      {% if building.rental_deposit_label or building.rental_key_money_label %}
+      <div class="fact-row{% if not (building.rental_deposit_label and building.rental_key_money_label) %} fact-row--single{% endif %}">
+      {% if building.rental_deposit_label %}<div class="fact"><dt>敷金</dt><dd>{{ building.rental_deposit_label }}</dd></div>{% endif %}
+      {% if building.rental_key_money_label %}<div class="fact"><dt>礼金</dt><dd>{{ building.rental_key_money_label }}</dd></div>{% endif %}
+      </div>
+      {% endif %}
       {% else %}
-      <div class="fact"><dt>補足</dt><dd>現在、この建物の募集は確認できていません。ご希望に近いお部屋もご案内可能です。</dd></div>
+      <div class="fact-row fact-row--single"><div class="fact fact--wide"><dt>補足</dt><dd>現在、この建物の募集は確認できていません。ご希望に近いお部屋もご案内可能です。</dd></div></div>
       {% endif %}
     </dl>
   </section>
 
   <section class="info card{% if is_both_mode %} mode-panel{% endif %}" aria-label="建物概要" {% if is_both_mode %}data-mode-panel="rental"{% endif %}>
-    <h2>建物概要</h2>
+    <h2 class="a11y-only">建物概要</h2>
     <dl class="facts">
+      <div class="fact-row{% if not (building.built_label and building.display_structure) %} fact-row--single{% endif %}">
       {% if building.built_label %}<div class="fact"><dt>築年月</dt><dd>{{ building.built_label }}</dd></div>{% endif %}
       {% if building.display_structure %}<div class="fact"><dt>構造</dt><dd>{{ building.display_structure }}</dd></div>{% endif %}
+      </div>
       {% set floor_count_text = (building.sale_summary.floor_count_text if building.sale_summary and building.sale_summary.floor_count_text else building.floor_count_text) %}
-      {% if floor_count_text %}<div class="fact"><dt>階建て</dt><dd>{{ floor_count_text }}</dd></div>{% endif %}
       {% set total_units = (building.sale_summary.total_units if building.sale_summary and building.sale_summary.total_units else building.total_units) %}
+      <div class="fact-row{% if not (floor_count_text and total_units) %} fact-row--single{% endif %}">
+      {% if floor_count_text %}<div class="fact"><dt>階建て</dt><dd>{{ floor_count_text }}</dd></div>{% endif %}
       {% if total_units %}<div class="fact"><dt>総戸数</dt><dd>{{ total_units }}</dd></div>{% endif %}
-      {% if building.access_info %}<div class="fact"><dt>交通</dt><dd>{{ building.access_info }}</dd></div>{% endif %}
+      </div>
+      {% if building.access_info %}<div class="fact-row fact-row--single"><div class="fact fact--wide"><dt>交通</dt><dd>{{ building.access_info }}</dd></div></div>{% endif %}
     </dl>
   </section>
   <section class="line-cta card{% if is_both_mode %} mode-panel{% endif %}" aria-label="賃貸のお問い合わせ" {% if is_both_mode %}data-mode-panel="rental"{% endif %}>


### PR DESCRIPTION
### Motivation
- Align the front templates so Mansion Review–derived summary data is presented in a stable, predictable two-column order inside the existing cards while keeping the current visual design and behavior unchanged.

### Description
- Updated `templates/building.html.j2` and `templates_v2/building.html.j2` to convert visible card headings into screen-reader-only `h2` (`.a11y-only`) and to implement an internal two-column row layout (`.fact-row`, `.fact-row--single`, `.fact--wide`) without changing card containers or theme.
- Reordered card fields to the requested contracts: Rental: 空室/賃料 → 入居可能日/管理費・共益費 → 間取り/面積 → 敷金/礼金; Sale: 販売状況/価格 → 所在階/向き → 間取り/面積 → ㎡単価(全幅); Building facts: 築年月/構造 → 階建て/総戸数 → 交通(全幅). 
- Implemented missing-value fallbacks in templates so rows collapse to single-column and pair rows behave per the rules (敷金/礼金 hidden if both missing, single-side full-width if only one present, ㎡単価 omitted when absent, 交通 full-width and wraps). 
- No changes were made to `render/build.py` or `normalize/building_summaries.py`; data paths and render logic remain intact and unchanged.

### Testing
- Verified Jinja template parsing with `Environment(FileSystemLoader).get_template('building.html.j2')` for both `templates` and `templates_v2`, and both loaded successfully. (pass)
- Ran `pytest -q tests/test_render_dist.py` and observed 44 tests passing and 2 failures; the failures are pre-existing/branch-level expectations related to detail filename and v2 min JSON contract, not caused by the template reorder. (44 passed, 2 failed)
- Attempted a full render (`PYTHONPATH=src python -m tatemono_map.render.build --db-path data/public/public.sqlite3 --output-dir dist --version v2`) in this environment but the run did not complete stably due to concurrent `dist` cleanup contention in the container, so a clean end-to-end build could not be produced here. (not completed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dabf8d81848326ac918662612a02d6)