### PR TITLE
Align sale/rental/building cards: field-level current values & mobile 2-column fixes

### DIFF
--- a/src/tatemono_map/normalize/building_summaries.py
+++ b/src/tatemono_map/normalize/building_summaries.py
@@ -84,6 +84,19 @@ def _pick_latest_valid_value(rows: list[dict], field: str, *, validator=None):
     return None
 
 
+def _pick_latest_nonempty_listing_field(rows: list, field: str):
+    for row in sorted(rows, key=lambda r: (normalize_text(r["updated_at"]) or ""), reverse=True):
+        value = row[field]
+        if value is None:
+            continue
+        if isinstance(value, str):
+            value = normalize_text(value)
+            if not value:
+                continue
+        return value
+    return None
+
+
 def _nearest_availability_date(items: list) -> str | None:
     dates: list[date] = []
     for row in items:
@@ -304,12 +317,23 @@ def rebuild(db_path: str) -> int:
         sale_directions = sorted({normalize_text(r["direction_text"]) for r in sale_items if normalize_text(r["direction_text"])})
         sale_latest = max((r["updated_at"] for r in sale_items if r["updated_at"]), default=None)
 
-        sale_price_min = min(sale_prices) if sale_prices else (building["sale_price_yen_min"] if building else None)
-        sale_price_max = max(sale_prices) if sale_prices else (building["sale_price_yen_max"] if building else None)
-        sale_price_avg = (sum(sale_prices) // len(sale_prices)) if sale_prices else (building["sale_price_yen_avg"] if building else None)
-        sale_area_min = min(sale_areas) if sale_areas else (building["sale_area_sqm_min"] if building else None)
-        sale_area_max = max(sale_areas) if sale_areas else (building["sale_area_sqm_max"] if building else None)
-        sale_layout_types_json = json.dumps(sale_layouts, ensure_ascii=False) if sale_layouts else (building["sale_layout_types_json"] if building else None)
+        sale_price_current = _pick_latest_nonempty_listing_field(sale_items, "price_yen")
+        sale_area_current = _pick_latest_nonempty_listing_field(sale_items, "area_sqm")
+        sale_layout_current = _pick_latest_nonempty_listing_field(sale_items, "layout")
+        sale_floor_current = _pick_latest_nonempty_listing_field(sale_items, "floor_text")
+        sale_direction_current = _pick_latest_nonempty_listing_field(sale_items, "direction_text")
+        sale_sqm_unit_price_current = _pick_latest_nonempty_listing_field(sale_items, "sqm_unit_price_yen")
+
+        sale_price_min = sale_price_current if sale_price_current is not None else (min(sale_prices) if sale_prices else (building["sale_price_yen_min"] if building else None))
+        sale_price_max = sale_price_current if sale_price_current is not None else (max(sale_prices) if sale_prices else (building["sale_price_yen_max"] if building else None))
+        sale_price_avg = int(sale_price_current) if sale_price_current is not None else ((sum(sale_prices) // len(sale_prices)) if sale_prices else (building["sale_price_yen_avg"] if building else None))
+        sale_area_min = sale_area_current if sale_area_current is not None else (min(sale_areas) if sale_areas else (building["sale_area_sqm_min"] if building else None))
+        sale_area_max = sale_area_current if sale_area_current is not None else (max(sale_areas) if sale_areas else (building["sale_area_sqm_max"] if building else None))
+        sale_layout_types_json = (
+            json.dumps([sale_layout_current], ensure_ascii=False)
+            if sale_layout_current
+            else (json.dumps(sale_layouts, ensure_ascii=False) if sale_layouts else (building["sale_layout_types_json"] if building else None))
+        )
         sale_listing_count = len(sale_items) if sale_items else (building["sale_listing_count"] if building else None)
 
         availability_label = (_select_availability_label(move_in_dates, items) if items else None) or fallback_availability_label
@@ -445,10 +469,10 @@ def rebuild(db_path: str) -> int:
                     sale_area_min,
                     sale_area_max,
                     sale_layout_types_json or "[]",
-                    ", ".join(sale_floors) if sale_floors else None,
-                    ", ".join(sale_directions) if sale_directions else None,
-                    min(sale_sqm_unit_prices) if sale_sqm_unit_prices else None,
-                    max(sale_sqm_unit_prices) if sale_sqm_unit_prices else None,
+                    sale_floor_current or (", ".join(sale_floors) if sale_floors else None),
+                    sale_direction_current or (", ".join(sale_directions) if sale_directions else None),
+                    sale_sqm_unit_price_current if sale_sqm_unit_price_current is not None else (min(sale_sqm_unit_prices) if sale_sqm_unit_prices else None),
+                    sale_sqm_unit_price_current if sale_sqm_unit_price_current is not None else (max(sale_sqm_unit_prices) if sale_sqm_unit_prices else None),
                     min(sale_mgmt_fees) if sale_mgmt_fees else None,
                     max(sale_mgmt_fees) if sale_mgmt_fees else None,
                     min(sale_repair_funds) if sale_repair_funds else None,

--- a/src/tatemono_map/render/build.py
+++ b/src/tatemono_map/render/build.py
@@ -892,6 +892,7 @@ def _load_buildings(db_path: str) -> tuple[list[dict], int, int, int, int]:
     ).fetchall()
     rental_terms_map: dict[str, dict[str, list[object]]] = {}
     rental_current_map: dict[str, dict[str, object]] = {}
+    sale_current_map: dict[str, dict[str, object]] = {}
     for row in rental_terms_rows:
         building_key = str(row["building_key"] or "").strip()
         if not building_key:
@@ -916,6 +917,51 @@ def _load_buildings(db_path: str) -> tuple[list[dict], int, int, int, int]:
         floor_text = str(row["floor_text"] or "").strip()
         if floor_text and floor_text not in current["floors"]:
             current["floors"].append(floor_text)
+    sale_rows = conn.execute(
+        """
+        SELECT building_key, price_yen, area_sqm, layout, floor_text, direction_text, tsubo_unit_price_yen
+        FROM sale_listings
+        WHERE (
+            ingest_run_id IN (SELECT ingest_run_id FROM current_ingest_snapshots)
+            OR (
+                ingest_run_id IS NULL
+                AND NOT EXISTS (SELECT 1 FROM current_ingest_snapshots)
+            )
+        )
+        ORDER BY id DESC
+        """
+    ).fetchall()
+    for row in sale_rows:
+        building_key = str(row["building_key"] or "").strip()
+        if not building_key:
+            continue
+        canonical_key = alias_map.get(building_key, building_key)
+        current = sale_current_map.setdefault(
+            canonical_key,
+            {
+                "price_yen": None,
+                "area_sqm": None,
+                "layout": None,
+                "floor_text": None,
+                "direction_text": None,
+                "tsubo_unit_price_yen": None,
+            },
+        )
+        if current["price_yen"] is None and row["price_yen"] is not None:
+            current["price_yen"] = row["price_yen"]
+        if current["area_sqm"] is None and row["area_sqm"] is not None:
+            current["area_sqm"] = row["area_sqm"]
+        layout = str(row["layout"] or "").strip()
+        if current["layout"] is None and layout:
+            current["layout"] = layout
+        floor_text = str(row["floor_text"] or "").strip()
+        if current["floor_text"] is None and floor_text:
+            current["floor_text"] = floor_text
+        direction_text = str(row["direction_text"] or "").strip()
+        if current["direction_text"] is None and direction_text:
+            current["direction_text"] = direction_text
+        if current["tsubo_unit_price_yen"] is None and row["tsubo_unit_price_yen"] is not None:
+            current["tsubo_unit_price_yen"] = row["tsubo_unit_price_yen"]
     merged_rental_summary_map: dict[str, dict] = {}
     for key, row in rental_summary_map.items():
         canonical_key = alias_map.get(key, key)
@@ -954,6 +1000,7 @@ def _load_buildings(db_path: str) -> tuple[list[dict], int, int, int, int]:
         building["rental_deposit_label"] = _format_text_label(rental_terms.get("deposit", []))
         building["rental_key_money_label"] = _format_text_label(rental_terms.get("key_money", []))
         building["rental_current"] = rental_current_map.get(str(building.get("building_key")), {})
+        building["sale_current"] = sale_current_map.get(str(building.get("building_key")), {})
     print(
         "render_kpi_counts canonical_buildings_count={} summary_buildings_count={} vacancy_total={}".format(
             canonical_buildings_count,
@@ -1266,27 +1313,34 @@ def _build_dist_version(
         b["access_info"] = _format_access_info_for_display(b.get("access_info"))
         b["display_structure"] = _normalize_structure_label(b.get("building_structure") or b.get("structure"))
         sale_count = sale_summary.get("sale_listing_count") if sale_summary else b.get("sale_listing_count")
+        sale_current = b.get("sale_current") or {}
         b["sale_status_label"] = f"{int(sale_count)}件" if (sale_count or 0) > 0 else "現在、販売中の住戸はありません。"
+        sale_price_current = sale_current.get("price_yen")
         b["sale_price_label"] = _format_range(
-            (sale_summary.get("price_yen_min") if sale_summary else b.get("sale_price_yen_min")) / 10000 if (sale_summary.get("price_yen_min") if sale_summary else b.get("sale_price_yen_min")) else None,
-            (sale_summary.get("price_yen_max") if sale_summary else b.get("sale_price_yen_max")) / 10000 if (sale_summary.get("price_yen_max") if sale_summary else b.get("sale_price_yen_max")) else None,
+            (sale_price_current / 10000) if sale_price_current is not None else ((sale_summary.get("price_yen_min") if sale_summary else b.get("sale_price_yen_min")) / 10000 if (sale_summary.get("price_yen_min") if sale_summary else b.get("sale_price_yen_min")) else None),
+            (sale_price_current / 10000) if sale_price_current is not None else ((sale_summary.get("price_yen_max") if sale_summary else b.get("sale_price_yen_max")) / 10000 if (sale_summary.get("price_yen_max") if sale_summary else b.get("sale_price_yen_max")) else None),
             suffix="万円",
         )
+        sale_area_current = sale_current.get("area_sqm")
         b["sale_area_label"] = _format_range(
-            sale_summary.get("area_sqm_min") if sale_summary else b.get("sale_area_sqm_min"),
-            sale_summary.get("area_sqm_max") if sale_summary else b.get("sale_area_sqm_max"),
+            sale_area_current if sale_area_current is not None else (sale_summary.get("area_sqm_min") if sale_summary else b.get("sale_area_sqm_min")),
+            sale_area_current if sale_area_current is not None else (sale_summary.get("area_sqm_max") if sale_summary else b.get("sale_area_sqm_max")),
             suffix="㎡",
         )
-        b["sale_layout_label"] = _format_layout_label(
-            json.loads(sale_summary.get("layout_types_json") or "[]")
-        ) if sale_summary else _format_layout_label(json.loads(b.get("sale_layout_types_json") or "[]"))
+        sale_layout_current = sale_current.get("layout")
+        b["sale_layout_label"] = (
+            _format_layout_label([sale_layout_current])
+            if sale_layout_current
+            else (_format_layout_label(json.loads(sale_summary.get("layout_types_json") or "[]")) if sale_summary else _format_layout_label(json.loads(b.get("sale_layout_types_json") or "[]")))
+        )
+        sqm_unit_current = sale_current.get("tsubo_unit_price_yen")
         b["sale_sqm_price_label"] = _format_range(
-            (sale_summary.get("tsubo_unit_price_yen_min") / 10000) if sale_summary and sale_summary.get("tsubo_unit_price_yen_min") else None,
-            (sale_summary.get("tsubo_unit_price_yen_max") / 10000) if sale_summary and sale_summary.get("tsubo_unit_price_yen_max") else None,
+            (sqm_unit_current / 10000) if sqm_unit_current is not None else ((sale_summary.get("tsubo_unit_price_yen_min") / 10000) if sale_summary and sale_summary.get("tsubo_unit_price_yen_min") else None),
+            (sqm_unit_current / 10000) if sqm_unit_current is not None else ((sale_summary.get("tsubo_unit_price_yen_max") / 10000) if sale_summary and sale_summary.get("tsubo_unit_price_yen_max") else None),
             suffix="万円/m²",
         )
-        b["sale_floor_label"] = sale_summary.get("floor_summary") if sale_summary else None
-        b["sale_direction_label"] = sale_summary.get("direction_summary") if sale_summary else None
+        b["sale_floor_label"] = sale_current.get("floor_text") or (sale_summary.get("floor_summary") if sale_summary else None)
+        b["sale_direction_label"] = sale_current.get("direction_text") or (sale_summary.get("direction_summary") if sale_summary else None)
         seo = _build_building_seo(b, site_origin=site_origin, base_path=base_path)
         detail_path = f"{base_path}/b/{b['detail_filename']}"
         area_hub = None

--- a/templates/building.html.j2
+++ b/templates/building.html.j2
@@ -73,6 +73,12 @@
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 10px;
+    border-top: 1px dashed var(--border);
+    padding-top: 8px;
+  }
+  .fact-row:first-child {
+    border-top: 0;
+    padding-top: 0;
   }
   .fact-row--single {
     grid-template-columns: minmax(0, 1fr);
@@ -83,12 +89,6 @@
     display: grid;
     grid-template-columns: 140px minmax(0, 1fr);
     gap: 10px;
-    border-top: 1px dashed var(--border);
-    padding-top: 8px;
-  }
-  .fact-row:first-child .fact {
-    border-top: 0;
-    padding-top: 0;
   }
   .fact--wide { grid-column: 1 / -1; }
 
@@ -136,9 +136,6 @@
   .mode-panel[hidden] { display: none; }
 
   @media (max-width: 740px) {
-    .fact-row {
-      grid-template-columns: minmax(0, 1fr);
-    }
     .fact {
       grid-template-columns: 1fr;
       gap: 4px;
@@ -267,17 +264,24 @@
         {% else %}
         <div class="fact-row fact-row--single"><div class="fact fact--wide"><dt>補足</dt><dd>現在、この建物の募集は確認できていません。ご希望に近いお部屋もご案内可能です。</dd></div></div>
         {% endif %}
-      <div class="fact-row{% if not (building.built_label and building.display_structure) %} fact-row--single{% endif %}">
-      {% if building.built_label %}<div class="fact"><dt>築年月</dt><dd>{{ building.built_label }}</dd></div>{% endif %}
-      {% if building.display_structure %}<div class="fact"><dt>構造</dt><dd>{{ building.display_structure }}</dd></div>{% endif %}
-      </div>
-      {% set floor_count_text = (building.sale_summary.floor_count_text if building.sale_summary and building.sale_summary.floor_count_text else building.floor_count_text) %}
-      {% set total_units = (building.sale_summary.total_units if building.sale_summary and building.sale_summary.total_units else building.total_units) %}
-      <div class="fact-row{% if not (floor_count_text and total_units) %} fact-row--single{% endif %}">
-      {% if floor_count_text %}<div class="fact"><dt>階建て</dt><dd>{{ floor_count_text }}</dd></div>{% endif %}
-      {% if total_units %}<div class="fact"><dt>総戸数</dt><dd>{{ total_units }}</dd></div>{% endif %}
-      </div>
-      {% if building.access_info %}<div class="fact-row fact-row--single"><div class="fact fact--wide"><dt>交通</dt><dd>{{ building.access_info }}</dd></div></div>{% endif %}
+      </dl>
+    </section>
+    {% endif %}
+    {% if show_rental %}
+    <section class="info card" aria-label="建物概要">
+      <h2 class="a11y-only">建物概要</h2>
+      <dl class="facts">
+        <div class="fact-row{% if not (building.built_label and building.display_structure) %} fact-row--single{% endif %}">
+        {% if building.built_label %}<div class="fact"><dt>築年月</dt><dd>{{ building.built_label }}</dd></div>{% endif %}
+        {% if building.display_structure %}<div class="fact"><dt>構造</dt><dd>{{ building.display_structure }}</dd></div>{% endif %}
+        </div>
+        {% set floor_count_text = (building.sale_summary.floor_count_text if building.sale_summary and building.sale_summary.floor_count_text else building.floor_count_text) %}
+        {% set total_units = (building.sale_summary.total_units if building.sale_summary and building.sale_summary.total_units else building.total_units) %}
+        <div class="fact-row{% if not (floor_count_text and total_units) %} fact-row--single{% endif %}">
+        {% if floor_count_text %}<div class="fact"><dt>階建て</dt><dd>{{ floor_count_text }}</dd></div>{% endif %}
+        {% if total_units %}<div class="fact"><dt>総戸数</dt><dd>{{ total_units }}</dd></div>{% endif %}
+        </div>
+        {% if building.access_info %}<div class="fact-row fact-row--single"><div class="fact fact--wide"><dt>交通</dt><dd>{{ building.access_info }}</dd></div></div>{% endif %}
       </dl>
     </section>
     {% endif %}

--- a/templates_v2/building.html.j2
+++ b/templates_v2/building.html.j2
@@ -26,10 +26,10 @@
     border: 0;
   }
   .facts { margin: 0; display: grid; gap: 10px; }
-  .fact-row { margin: 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+  .fact-row { margin: 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; border-top: 1px solid var(--border-soft); padding-top: 9px; }
+  .fact-row:first-child { border-top: 0; padding-top: 0; }
   .fact-row--single { grid-template-columns: minmax(0, 1fr); }
-  .fact { margin: 0; display: grid; grid-template-columns: 128px minmax(0,1fr); border-top: 1px solid var(--border-soft); padding-top: 9px; }
-  .fact-row:first-child .fact { border-top: 0; padding-top: 0; }
+  .fact { margin: 0; display: grid; grid-template-columns: 128px minmax(0,1fr); }
   .fact--wide { grid-column: 1 / -1; }
   .fact dt { color: var(--muted); }
   .fact dd { margin: 0; font-weight: 600; }
@@ -58,7 +58,6 @@
     .map-embed-frame { height: 340px; }
   }
   @media (max-width: 740px) {
-    .fact-row { grid-template-columns: minmax(0, 1fr); }
     .fact { grid-template-columns: 1fr; gap: 2px; }
     .line-cta .button { max-width: none; width: 100%; }
   }


### PR DESCRIPTION
### Motivation
- Ensure Mansion Review–sourced current data actually wins through to front end and avoid stale/empty summary values overriding newer per-field data. 
- Restore the front display contract so 賃貸/分譲/建物概要 rows render in the exact 2-column / full-width pattern required on mobile and desktop. 
- Fix row separator rendering so removing visible headings does not remove natural row dividers, using minimal changes to summary/render/template layers.

### Description
- Summary: added `_pick_latest_nonempty_listing_field` and use it when building sale summary fields so price/area/layout/floor/direction/㎡単価 prefer the latest non-empty listing field instead of only aggregate min/max. (src/tatemono_map/normalize/building_summaries.py)
- Render: added canonical `sale_current` aggregation from `sale_listings` and made template labels prefer `sale_current` per-field when present (price, area, layout, floor, direction, tsubo/㎡ unit price). (src/tatemono_map/render/build.py)
- Templates: restored row-level separators and padding and kept `.fact-row` two-column grid on mobile except when `fact-row--single` forces full-width; preserved wide rows for 交通 and ㎡単価 and moved rental-side building overview into a stable separate card to keep contracts consistent. (templates/building.html.j2, templates_v2/building.html.j2)
- Minimal scope: changes limited to the requested files and kept existing styling/font/spacing; no crawler/raw_block or large refactors.

### Testing
- `python -m py_compile src/tatemono_map/normalize/building_summaries.py src/tatemono_map/render/build.py` — succeeded. 
- `PYTHONPATH=src python -m tatemono_map.normalize.building_summaries --db-path data/public/public.sqlite3` — succeeded and rebuilt summaries. 
- `PYTHONPATH=src python -m tatemono_map.render.build --db-path data/public/public.sqlite3 --output-dir /tmp/tatemono-dist --version all` — started but could not be fully completed within this environment due to long runtime; process was observed and then terminated. 
- Verified DB shape via automated query showing `listings=0` and `sale_listings=0` in the shipped sample DB, which prevented per-property visual verification here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db45f2f4908326bd32458048634100)