### PR TITLE
Fix shifted field bindings in sale cards for Mansion Review data

### DIFF
--- a/src/tatemono_map/normalize/building_summaries.py
+++ b/src/tatemono_map/normalize/building_summaries.py
@@ -97,6 +97,35 @@ def _pick_latest_nonempty_listing_field(rows: list, field: str):
     return None
 
 
+_SALE_LAYOUT_RE = re.compile(r"\d+\s*(?:SLDK|LDK|SDK|DK|K|R|ワンルーム)", re.IGNORECASE)
+
+
+def _normalize_sale_row_fields(row: dict) -> dict:
+    normalized = dict(row)
+    floor_text = normalize_text(normalized.get("floor_text"))
+    direction_text = normalize_text(normalized.get("direction_text"))
+    layout = normalize_text(normalized.get("layout"))
+    area_sqm = normalized.get("area_sqm")
+    sqm_unit_price_yen = normalized.get("sqm_unit_price_yen")
+
+    if area_sqm is None and floor_text and re.search(r"(?:㎡|m2|m²)", floor_text, flags=re.IGNORECASE):
+        area_match = re.search(r"(\d+(?:\.\d+)?)", floor_text.replace(",", ""))
+        if area_match:
+            normalized["area_sqm"] = float(area_match.group(1))
+            normalized["floor_text"] = None
+            floor_text = None
+
+    if layout and sqm_unit_price_yen is None and re.search(r"万円", layout):
+        match = re.search(r"(\d+(?:\.\d+)?)", layout.replace(",", ""))
+        if match:
+            normalized["sqm_unit_price_yen"] = int(float(match.group(1)) * 10000)
+            normalized["layout"] = direction_text if direction_text and _SALE_LAYOUT_RE.search(direction_text) else None
+            if direction_text and _SALE_LAYOUT_RE.search(direction_text):
+                normalized["direction_text"] = None
+
+    return normalized
+
+
 def _nearest_availability_date(items: list) -> str | None:
     dates: list[date] = []
     for row in items:
@@ -307,22 +336,23 @@ def rebuild(db_path: str) -> int:
         fallback_availability_label = (normalize_text(building["availability_label"]) if building else "") or None
         fallback_property_kind = normalize_text(building["property_kind"]) if building and building["property_kind"] else ""
 
-        sale_prices = [int(r["price_yen"]) for r in sale_items if r["price_yen"] is not None]
-        sale_areas = [float(r["area_sqm"]) for r in sale_items if r["area_sqm"] is not None]
-        sale_layouts = sorted({normalize_text(r["layout"]) for r in sale_items if r["layout"]})
-        sale_mgmt_fees = [int(r["management_fee_yen"]) for r in sale_items if r["management_fee_yen"] is not None]
-        sale_repair_funds = [int(r["repair_fund_yen"]) for r in sale_items if r["repair_fund_yen"] is not None]
-        sale_sqm_unit_prices = [int(r["sqm_unit_price_yen"]) for r in sale_items if r["sqm_unit_price_yen"] is not None]
-        sale_floors = sorted({normalize_text(r["floor_text"]) for r in sale_items if normalize_text(r["floor_text"])})
-        sale_directions = sorted({normalize_text(r["direction_text"]) for r in sale_items if normalize_text(r["direction_text"])})
+        normalized_sale_items = [_normalize_sale_row_fields(dict(r)) for r in sale_items]
+        sale_prices = [int(r["price_yen"]) for r in normalized_sale_items if r["price_yen"] is not None]
+        sale_areas = [float(r["area_sqm"]) for r in normalized_sale_items if r["area_sqm"] is not None]
+        sale_layouts = sorted({normalize_text(r["layout"]) for r in normalized_sale_items if r["layout"]})
+        sale_mgmt_fees = [int(r["management_fee_yen"]) for r in normalized_sale_items if r["management_fee_yen"] is not None]
+        sale_repair_funds = [int(r["repair_fund_yen"]) for r in normalized_sale_items if r["repair_fund_yen"] is not None]
+        sale_sqm_unit_prices = [int(r["sqm_unit_price_yen"]) for r in normalized_sale_items if r["sqm_unit_price_yen"] is not None]
+        sale_floors = sorted({normalize_text(r["floor_text"]) for r in normalized_sale_items if normalize_text(r["floor_text"])})
+        sale_directions = sorted({normalize_text(r["direction_text"]) for r in normalized_sale_items if normalize_text(r["direction_text"])})
         sale_latest = max((r["updated_at"] for r in sale_items if r["updated_at"]), default=None)
 
-        sale_price_current = _pick_latest_nonempty_listing_field(sale_items, "price_yen")
-        sale_area_current = _pick_latest_nonempty_listing_field(sale_items, "area_sqm")
-        sale_layout_current = _pick_latest_nonempty_listing_field(sale_items, "layout")
-        sale_floor_current = _pick_latest_nonempty_listing_field(sale_items, "floor_text")
-        sale_direction_current = _pick_latest_nonempty_listing_field(sale_items, "direction_text")
-        sale_sqm_unit_price_current = _pick_latest_nonempty_listing_field(sale_items, "sqm_unit_price_yen")
+        sale_price_current = _pick_latest_nonempty_listing_field(normalized_sale_items, "price_yen")
+        sale_area_current = _pick_latest_nonempty_listing_field(normalized_sale_items, "area_sqm")
+        sale_layout_current = _pick_latest_nonempty_listing_field(normalized_sale_items, "layout")
+        sale_floor_current = _pick_latest_nonempty_listing_field(normalized_sale_items, "floor_text")
+        sale_direction_current = _pick_latest_nonempty_listing_field(normalized_sale_items, "direction_text")
+        sale_sqm_unit_price_current = _pick_latest_nonempty_listing_field(normalized_sale_items, "sqm_unit_price_yen")
 
         sale_price_min = sale_price_current if sale_price_current is not None else (min(sale_prices) if sale_prices else (building["sale_price_yen_min"] if building else None))
         sale_price_max = sale_price_current if sale_price_current is not None else (max(sale_prices) if sale_prices else (building["sale_price_yen_max"] if building else None))

--- a/src/tatemono_map/render/build.py
+++ b/src/tatemono_map/render/build.py
@@ -215,6 +215,37 @@ def _format_text_label(values: list[object]) -> str | None:
     return f"{labels[0]}〜{labels[-1]}"
 
 
+_SALE_LAYOUT_RE = re.compile(r"\d+\s*(?:SLDK|LDK|SDK|DK|K|R|ワンルーム)", re.IGNORECASE)
+
+
+def _normalize_sale_binding_row(row: dict[str, object]) -> dict[str, object]:
+    normalized = dict(row)
+    floor_text = str(normalized.get("floor_text") or "").strip()
+    direction_text = str(normalized.get("direction_text") or "").strip()
+    layout = str(normalized.get("layout") or "").strip()
+    area_sqm = normalized.get("area_sqm")
+    sqm_unit_price_yen = normalized.get("tsubo_unit_price_yen")
+
+    if area_sqm is None and floor_text and re.search(r"(?:㎡|m2|m²)", floor_text, flags=re.IGNORECASE):
+        area_match = re.search(r"(\d+(?:\.\d+)?)", floor_text.replace(",", ""))
+        if area_match:
+            normalized["area_sqm"] = float(area_match.group(1))
+            normalized["floor_text"] = None
+            floor_text = ""
+
+    if layout and sqm_unit_price_yen is None and "万円" in layout:
+        match = re.search(r"(\d+(?:\.\d+)?)", layout.replace(",", ""))
+        if match:
+            normalized["tsubo_unit_price_yen"] = int(float(match.group(1)) * 10000)
+            if direction_text and _SALE_LAYOUT_RE.search(direction_text):
+                normalized["layout"] = direction_text
+                normalized["direction_text"] = None
+            else:
+                normalized["layout"] = None
+
+    return normalized
+
+
 def _sanitize_text(value: str) -> str:
     sanitized = ROOM_SUFFIX_RE.sub("", value)
     return re.sub(r"\s{2,}", " ", sanitized).strip()
@@ -931,7 +962,8 @@ def _load_buildings(db_path: str) -> tuple[list[dict], int, int, int, int]:
         ORDER BY id DESC
         """
     ).fetchall()
-    for row in sale_rows:
+    for raw_row in sale_rows:
+        row = _normalize_sale_binding_row(dict(raw_row))
         building_key = str(row["building_key"] or "").strip()
         if not building_key:
             continue

--- a/templates/building.html.j2
+++ b/templates/building.html.j2
@@ -212,9 +212,9 @@
           {% if building.sale_floor_label %}<div class="fact"><dt>所在階</dt><dd>{{ building.sale_floor_label }}</dd></div>{% endif %}
           {% if building.sale_direction_label %}<div class="fact"><dt>向き</dt><dd>{{ building.sale_direction_label }}</dd></div>{% endif %}
         </div>
-        <div class="fact-row">
-          <div class="fact"><dt>間取り</dt><dd>{{ building.sale_layout_label or "要確認" }}</dd></div>
-          <div class="fact"><dt>面積</dt><dd>{{ building.sale_area_label or "要確認" }}</dd></div>
+        <div class="fact-row{% if not (building.sale_layout_label and building.sale_area_label) %} fact-row--single{% endif %}">
+          {% if building.sale_layout_label %}<div class="fact"><dt>間取り</dt><dd>{{ building.sale_layout_label }}</dd></div>{% endif %}
+          {% if building.sale_area_label %}<div class="fact"><dt>面積</dt><dd>{{ building.sale_area_label }}</dd></div>{% endif %}
         </div>
         {% if building.sale_sqm_price_label %}<div class="fact-row fact-row--single"><div class="fact fact--wide"><dt>㎡単価</dt><dd>{{ building.sale_sqm_price_label }}</dd></div></div>{% endif %}
         {% endif %}

--- a/templates_v2/building.html.j2
+++ b/templates_v2/building.html.j2
@@ -128,9 +128,13 @@
         <div class="fact"><dt>向き</dt><dd>{{ building.sale_direction_label }}</dd></div>
         {% endif %}
       </div>
-      <div class="fact-row">
-        <div class="fact"><dt>間取り</dt><dd>{{ building.sale_layout_label or "要確認" }}</dd></div>
-        <div class="fact"><dt>面積</dt><dd>{{ building.sale_area_label or "要確認" }}</dd></div>
+      <div class="fact-row{% if not (building.sale_layout_label and building.sale_area_label) %} fact-row--single{% endif %}">
+        {% if building.sale_layout_label %}
+        <div class="fact"><dt>間取り</dt><dd>{{ building.sale_layout_label }}</dd></div>
+        {% endif %}
+        {% if building.sale_area_label %}
+        <div class="fact"><dt>面積</dt><dd>{{ building.sale_area_label }}</dd></div>
+        {% endif %}
       </div>
       {% if building.sale_sqm_price_label %}
       <div class="fact-row fact-row--single">


### PR DESCRIPTION
### Motivation

- Some sale rows from the Mansion Review source arrive with positional shifts (e.g. `floor_text` containing an area, `direction_text` containing a layout, `layout` containing a ㎡単価), causing the sale card labels to display one-slot off.  
- The change must be minimal and limited to sale-card binding and rendering paths so other UI and rental cards remain unchanged.

### Description

- Added a normalization pass for sale rows in `src/tatemono_map/normalize/building_summaries.py` that re-binds named fields by meaning: `floor_text` → `area_sqm` when floor contains area-like text, and `layout` → `sqm_unit_price` when layout contains a price-like token, only moving `direction_text`→`layout` when direction looks like a layout.  
- Added the same normalization when building `sale_current_map` in `src/tatemono_map/render/build.py` so the current-data (fronted) rendering path uses the same named-field guard.  
- Updated templates `templates/building.html.j2` and `templates_v2/building.html.j2` to render `間取り` and `面積` as independent named fields (no fallback that can mask missing values) and to use the `fact-row--single` behavior when one side is missing.  
- All changes keep the existing card layout, CSS, and non-sale-card logic untouched and avoid wide refactors or crawler/ingest modifications.

### Testing

- Ran `python -m py_compile src/tatemono_map/normalize/building_summaries.py src/tatemono_map/render/build.py` which succeeded.  
- Ran a full static build with `PYTHONPATH=src python -m tatemono_map.render.build --db-path data/public/public.sqlite3 --output-dir /tmp/tmap-build-check --version all`, which completed and produced output (build artifacts present).  
- Note: the local `data/public/public.sqlite3` did not contain sale listings for the four named properties, so automated runs validated compilation and build flow but could not exercise the exact affected sample rows in this environment; please verify on a DB snapshot that contains Mansion Review sale rows for final confirmation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6d620b348326b2ae5d75f8893c8e)