### PR TITLE
分譲summaryを current sale listings の field-level 集約へ変更し一覧/詳細を整合

### DIFF
--- a/src/tatemono_map/normalize/building_summaries.py
+++ b/src/tatemono_map/normalize/building_summaries.py
@@ -100,6 +100,15 @@ def _pick_latest_nonempty_listing_field(rows: list, field: str):
 _SALE_LAYOUT_RE = re.compile(r"\d+\s*(?:SLDK|LDK|SDK|DK|K|R|ワンルーム)", re.IGNORECASE)
 
 
+def _natural_sort_key(value: str) -> tuple:
+    return tuple(int(part) if part.isdigit() else part.lower() for part in re.split(r"(\d+)", value))
+
+
+def _distinct_natural(values: list[str]) -> list[str]:
+    deduped = {normalize_text(v) for v in values if normalize_text(v)}
+    return sorted(deduped, key=_natural_sort_key)
+
+
 def _normalize_sale_row_fields(row: dict) -> dict:
     normalized = dict(row)
     floor_text = normalize_text(normalized.get("floor_text"))
@@ -339,30 +348,23 @@ def rebuild(db_path: str) -> int:
         normalized_sale_items = [_normalize_sale_row_fields(dict(r)) for r in sale_items]
         sale_prices = [int(r["price_yen"]) for r in normalized_sale_items if r["price_yen"] is not None]
         sale_areas = [float(r["area_sqm"]) for r in normalized_sale_items if r["area_sqm"] is not None]
-        sale_layouts = sorted({normalize_text(r["layout"]) for r in normalized_sale_items if r["layout"]})
+        sale_layouts = _distinct_natural([str(r.get("layout") or "") for r in normalized_sale_items])
         sale_mgmt_fees = [int(r["management_fee_yen"]) for r in normalized_sale_items if r["management_fee_yen"] is not None]
         sale_repair_funds = [int(r["repair_fund_yen"]) for r in normalized_sale_items if r["repair_fund_yen"] is not None]
         sale_sqm_unit_prices = [int(r["sqm_unit_price_yen"]) for r in normalized_sale_items if r["sqm_unit_price_yen"] is not None]
-        sale_floors = sorted({normalize_text(r["floor_text"]) for r in normalized_sale_items if normalize_text(r["floor_text"])})
-        sale_directions = sorted({normalize_text(r["direction_text"]) for r in normalized_sale_items if normalize_text(r["direction_text"])})
+        sale_floors = _distinct_natural([str(r.get("floor_text") or "") for r in normalized_sale_items])
+        sale_directions = _distinct_natural([str(r.get("direction_text") or "") for r in normalized_sale_items])
         sale_latest = max((r["updated_at"] for r in sale_items if r["updated_at"]), default=None)
 
-        sale_price_current = _pick_latest_nonempty_listing_field(normalized_sale_items, "price_yen")
-        sale_area_current = _pick_latest_nonempty_listing_field(normalized_sale_items, "area_sqm")
-        sale_layout_current = _pick_latest_nonempty_listing_field(normalized_sale_items, "layout")
-        sale_floor_current = _pick_latest_nonempty_listing_field(normalized_sale_items, "floor_text")
-        sale_direction_current = _pick_latest_nonempty_listing_field(normalized_sale_items, "direction_text")
-        sale_sqm_unit_price_current = _pick_latest_nonempty_listing_field(normalized_sale_items, "sqm_unit_price_yen")
-
-        sale_price_min = sale_price_current if sale_price_current is not None else (min(sale_prices) if sale_prices else (building["sale_price_yen_min"] if building else None))
-        sale_price_max = sale_price_current if sale_price_current is not None else (max(sale_prices) if sale_prices else (building["sale_price_yen_max"] if building else None))
-        sale_price_avg = int(sale_price_current) if sale_price_current is not None else ((sum(sale_prices) // len(sale_prices)) if sale_prices else (building["sale_price_yen_avg"] if building else None))
-        sale_area_min = sale_area_current if sale_area_current is not None else (min(sale_areas) if sale_areas else (building["sale_area_sqm_min"] if building else None))
-        sale_area_max = sale_area_current if sale_area_current is not None else (max(sale_areas) if sale_areas else (building["sale_area_sqm_max"] if building else None))
+        sale_price_min = min(sale_prices) if sale_prices else (building["sale_price_yen_min"] if building else None)
+        sale_price_max = max(sale_prices) if sale_prices else (building["sale_price_yen_max"] if building else None)
+        sale_price_avg = (sum(sale_prices) // len(sale_prices)) if sale_prices else (building["sale_price_yen_avg"] if building else None)
+        sale_area_min = min(sale_areas) if sale_areas else (building["sale_area_sqm_min"] if building else None)
+        sale_area_max = max(sale_areas) if sale_areas else (building["sale_area_sqm_max"] if building else None)
         sale_layout_types_json = (
-            json.dumps([sale_layout_current], ensure_ascii=False)
-            if sale_layout_current
-            else (json.dumps(sale_layouts, ensure_ascii=False) if sale_layouts else (building["sale_layout_types_json"] if building else None))
+            json.dumps(sale_layouts, ensure_ascii=False)
+            if sale_layouts
+            else (building["sale_layout_types_json"] if building else None)
         )
         sale_listing_count = len(sale_items) if sale_items else (building["sale_listing_count"] if building else None)
 
@@ -499,10 +501,10 @@ def rebuild(db_path: str) -> int:
                     sale_area_min,
                     sale_area_max,
                     sale_layout_types_json or "[]",
-                    sale_floor_current or (", ".join(sale_floors) if sale_floors else None),
-                    sale_direction_current or (", ".join(sale_directions) if sale_directions else None),
-                    sale_sqm_unit_price_current if sale_sqm_unit_price_current is not None else (min(sale_sqm_unit_prices) if sale_sqm_unit_prices else None),
-                    sale_sqm_unit_price_current if sale_sqm_unit_price_current is not None else (max(sale_sqm_unit_prices) if sale_sqm_unit_prices else None),
+                    ", ".join(sale_floors) if sale_floors else None,
+                    ", ".join(sale_directions) if sale_directions else None,
+                    min(sale_sqm_unit_prices) if sale_sqm_unit_prices else None,
+                    max(sale_sqm_unit_prices) if sale_sqm_unit_prices else None,
                     min(sale_mgmt_fees) if sale_mgmt_fees else None,
                     max(sale_mgmt_fees) if sale_mgmt_fees else None,
                     min(sale_repair_funds) if sale_repair_funds else None,

--- a/src/tatemono_map/render/build.py
+++ b/src/tatemono_map/render/build.py
@@ -218,6 +218,20 @@ def _format_text_label(values: list[object]) -> str | None:
 _SALE_LAYOUT_RE = re.compile(r"\d+\s*(?:SLDK|LDK|SDK|DK|K|R|ワンルーム)", re.IGNORECASE)
 
 
+def _natural_sort_key(value: str) -> tuple:
+    return tuple(int(part) if part.isdigit() else part.lower() for part in re.split(r"(\d+)", value))
+
+
+def _distinct_natural_text(values: list[object]) -> list[str]:
+    labels: dict[str, None] = {}
+    for value in values:
+        text = str(value or "").strip()
+        if not text or text in {"-", "--", "- -", "なし"}:
+            continue
+        labels.setdefault(text, None)
+    return sorted(labels.keys(), key=_natural_sort_key)
+
+
 def _normalize_sale_binding_row(row: dict[str, object]) -> dict[str, object]:
     normalized = dict(row)
     floor_text = str(normalized.get("floor_text") or "").strip()
@@ -971,29 +985,45 @@ def _load_buildings(db_path: str) -> tuple[list[dict], int, int, int, int]:
         current = sale_current_map.setdefault(
             canonical_key,
             {
-                "price_yen": None,
-                "area_sqm": None,
-                "layout": None,
-                "floor_text": None,
-                "direction_text": None,
-                "tsubo_unit_price_yen": None,
+                "listing_count": 0,
+                "price_values": [],
+                "area_values": [],
+                "sqm_price_values": [],
+                "layout_values": [],
+                "floor_values": [],
+                "direction_values": [],
             },
         )
-        if current["price_yen"] is None and row["price_yen"] is not None:
-            current["price_yen"] = row["price_yen"]
-        if current["area_sqm"] is None and row["area_sqm"] is not None:
-            current["area_sqm"] = row["area_sqm"]
-        layout = str(row["layout"] or "").strip()
-        if current["layout"] is None and layout:
-            current["layout"] = layout
-        floor_text = str(row["floor_text"] or "").strip()
-        if current["floor_text"] is None and floor_text:
-            current["floor_text"] = floor_text
-        direction_text = str(row["direction_text"] or "").strip()
-        if current["direction_text"] is None and direction_text:
-            current["direction_text"] = direction_text
-        if current["tsubo_unit_price_yen"] is None and row["tsubo_unit_price_yen"] is not None:
-            current["tsubo_unit_price_yen"] = row["tsubo_unit_price_yen"]
+        current["listing_count"] += 1
+        if row["price_yen"] is not None:
+            current["price_values"].append(int(row["price_yen"]))
+        if row["area_sqm"] is not None:
+            current["area_values"].append(float(row["area_sqm"]))
+        if row["tsubo_unit_price_yen"] is not None:
+            current["sqm_price_values"].append(int(row["tsubo_unit_price_yen"]))
+        current["layout_values"].append(row.get("layout"))
+        current["floor_values"].append(row.get("floor_text"))
+        current["direction_values"].append(row.get("direction_text"))
+
+    for canonical_key, current in sale_current_map.items():
+        price_values = current.get("price_values") or []
+        area_values = current.get("area_values") or []
+        sqm_price_values = current.get("sqm_price_values") or []
+        layout_list = _distinct_natural_text(current.get("layout_values") or [])
+        floor_list = _distinct_natural_text(current.get("floor_values") or [])
+        direction_list = _distinct_natural_text(current.get("direction_values") or [])
+        sale_current_map[canonical_key] = {
+            "listing_count": int(current.get("listing_count") or 0),
+            "price_min": min(price_values) if price_values else None,
+            "price_max": max(price_values) if price_values else None,
+            "area_min": min(area_values) if area_values else None,
+            "area_max": max(area_values) if area_values else None,
+            "sqm_price_min": min(sqm_price_values) if sqm_price_values else None,
+            "sqm_price_max": max(sqm_price_values) if sqm_price_values else None,
+            "layout_list": layout_list,
+            "floor_list": floor_list,
+            "direction_list": direction_list,
+        }
     merged_rental_summary_map: dict[str, dict] = {}
     for key, row in rental_summary_map.items():
         canonical_key = alias_map.get(key, key)
@@ -1214,6 +1244,18 @@ def _build_dist_version(
         b["address_full"] = b.get("address")
         b["display_address"] = _build_display_address(b.get("address"))
         b["render_address"] = b.get("display_address") if selected_mode == "short" else b.get("address_full")
+        sale_current = b.get("sale_current") or {}
+        sale_count = int(sale_current.get("listing_count") or 0)
+        sale_price_min = sale_current.get("price_min")
+        sale_price_max = sale_current.get("price_max")
+        sale_area_min = sale_current.get("area_min")
+        sale_area_max = sale_current.get("area_max")
+        b["sale_listing_count"] = sale_count
+        b["sale_price_yen_min"] = sale_price_min
+        b["sale_price_yen_max"] = sale_price_max
+        b["sale_price_yen_avg"] = int((sale_price_min + sale_price_max) / 2) if sale_price_min is not None and sale_price_max is not None else None
+        b["sale_area_sqm_min"] = sale_area_min
+        b["sale_area_sqm_max"] = sale_area_max
         has_sale = bool(b.get("has_sale")) or bool((b.get("sale_listing_count") or 0) > 0)
         has_rental = bool(b.get("has_rental")) or bool((b.get("vacancy_count") or 0) > 0)
         if has_sale and has_rental:
@@ -1344,35 +1386,39 @@ def _build_dist_version(
         b["rental_move_in_label"] = rental_summary.get("move_in_summary") if rental_summary else b.get("building_availability_label")
         b["access_info"] = _format_access_info_for_display(b.get("access_info"))
         b["display_structure"] = _normalize_structure_label(b.get("building_structure") or b.get("structure"))
-        sale_count = sale_summary.get("sale_listing_count") if sale_summary else b.get("sale_listing_count")
         sale_current = b.get("sale_current") or {}
-        b["sale_status_label"] = f"{int(sale_count)}件" if (sale_count or 0) > 0 else "現在、販売中の住戸はありません。"
-        sale_price_current = sale_current.get("price_yen")
+        sale_count = int(sale_current.get("listing_count") or 0)
+        b["sale_listing_count"] = sale_count
+        b["sale_status_label"] = f"{sale_count}件" if sale_count > 0 else "現在、販売中の住戸はありません。"
+        sale_price_min = sale_current.get("price_min")
+        sale_price_max = sale_current.get("price_max")
+        b["sale_price_yen_min"] = sale_price_min
+        b["sale_price_yen_max"] = sale_price_max
+        b["sale_price_yen_avg"] = int((sale_price_min + sale_price_max) / 2) if sale_price_min is not None and sale_price_max is not None else None
         b["sale_price_label"] = _format_range(
-            (sale_price_current / 10000) if sale_price_current is not None else ((sale_summary.get("price_yen_min") if sale_summary else b.get("sale_price_yen_min")) / 10000 if (sale_summary.get("price_yen_min") if sale_summary else b.get("sale_price_yen_min")) else None),
-            (sale_price_current / 10000) if sale_price_current is not None else ((sale_summary.get("price_yen_max") if sale_summary else b.get("sale_price_yen_max")) / 10000 if (sale_summary.get("price_yen_max") if sale_summary else b.get("sale_price_yen_max")) else None),
+            (sale_price_min / 10000) if sale_price_min is not None else None,
+            (sale_price_max / 10000) if sale_price_max is not None else None,
             suffix="万円",
         )
-        sale_area_current = sale_current.get("area_sqm")
+        sale_area_min = sale_current.get("area_min")
+        sale_area_max = sale_current.get("area_max")
+        b["sale_area_sqm_min"] = sale_area_min
+        b["sale_area_sqm_max"] = sale_area_max
         b["sale_area_label"] = _format_range(
-            sale_area_current if sale_area_current is not None else (sale_summary.get("area_sqm_min") if sale_summary else b.get("sale_area_sqm_min")),
-            sale_area_current if sale_area_current is not None else (sale_summary.get("area_sqm_max") if sale_summary else b.get("sale_area_sqm_max")),
+            sale_area_min,
+            sale_area_max,
             suffix="㎡",
         )
-        sale_layout_current = sale_current.get("layout")
-        b["sale_layout_label"] = (
-            _format_layout_label([sale_layout_current])
-            if sale_layout_current
-            else (_format_layout_label(json.loads(sale_summary.get("layout_types_json") or "[]")) if sale_summary else _format_layout_label(json.loads(b.get("sale_layout_types_json") or "[]")))
-        )
-        sqm_unit_current = sale_current.get("tsubo_unit_price_yen")
+        b["sale_layout_label"] = _format_layout_label(sale_current.get("layout_list") or [])
+        sqm_price_min = sale_current.get("sqm_price_min")
+        sqm_price_max = sale_current.get("sqm_price_max")
         b["sale_sqm_price_label"] = _format_range(
-            (sqm_unit_current / 10000) if sqm_unit_current is not None else ((sale_summary.get("tsubo_unit_price_yen_min") / 10000) if sale_summary and sale_summary.get("tsubo_unit_price_yen_min") else None),
-            (sqm_unit_current / 10000) if sqm_unit_current is not None else ((sale_summary.get("tsubo_unit_price_yen_max") / 10000) if sale_summary and sale_summary.get("tsubo_unit_price_yen_max") else None),
-            suffix="万円/m²",
+            (sqm_price_min / 10000) if sqm_price_min is not None else None,
+            (sqm_price_max / 10000) if sqm_price_max is not None else None,
+            suffix="万円/㎡",
         )
-        b["sale_floor_label"] = sale_current.get("floor_text") or (sale_summary.get("floor_summary") if sale_summary else None)
-        b["sale_direction_label"] = sale_current.get("direction_text") or (sale_summary.get("direction_summary") if sale_summary else None)
+        b["sale_floor_label"] = _format_text_label(sale_current.get("floor_list") or [])
+        b["sale_direction_label"] = _format_text_label(sale_current.get("direction_list") or [])
         seo = _build_building_seo(b, site_origin=site_origin, base_path=base_path)
         detail_path = f"{base_path}/b/{b['detail_filename']}"
         area_hub = None

--- a/templates/building.html.j2
+++ b/templates/building.html.j2
@@ -195,27 +195,31 @@
     <section class="info card mode-panel" aria-label="売出し情報" data-mode-panel="sale" {% if is_both_mode %}hidden{% endif %}>
       <h2 class="a11y-only">売出し情報</h2>
       <dl class="facts">
-        <div class="fact-row{% if not ((building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0) %} fact-row--single{% endif %}">
+        <div class="fact-row{% if not ((building.sale_listing_count or 0) > 0) %} fact-row--single{% endif %}">
           <div class="fact">
             <dt>販売状況</dt>
             <dd>{{ building.sale_status_label }}</dd>
           </div>
-          {% if (building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0 %}
+          {% if (building.sale_listing_count or 0) > 0 %}
           <div class="fact">
             <dt>価格</dt>
             <dd>{{ building.sale_price_label or "販売中" }}</dd>
           </div>
           {% endif %}
         </div>
-        {% if (building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0 %}
+        {% if (building.sale_listing_count or 0) > 0 %}
+        {% if building.sale_floor_label or building.sale_direction_label %}
         <div class="fact-row{% if not (building.sale_floor_label and building.sale_direction_label) %} fact-row--single{% endif %}">
           {% if building.sale_floor_label %}<div class="fact"><dt>所在階</dt><dd>{{ building.sale_floor_label }}</dd></div>{% endif %}
           {% if building.sale_direction_label %}<div class="fact"><dt>向き</dt><dd>{{ building.sale_direction_label }}</dd></div>{% endif %}
         </div>
+        {% endif %}
+        {% if building.sale_layout_label or building.sale_area_label %}
         <div class="fact-row{% if not (building.sale_layout_label and building.sale_area_label) %} fact-row--single{% endif %}">
           {% if building.sale_layout_label %}<div class="fact"><dt>間取り</dt><dd>{{ building.sale_layout_label }}</dd></div>{% endif %}
           {% if building.sale_area_label %}<div class="fact"><dt>面積</dt><dd>{{ building.sale_area_label }}</dd></div>{% endif %}
         </div>
+        {% endif %}
         {% if building.sale_sqm_price_label %}<div class="fact-row fact-row--single"><div class="fact fact--wide"><dt>㎡単価</dt><dd>{{ building.sale_sqm_price_label }}</dd></div></div>{% endif %}
         {% endif %}
       </dl>
@@ -289,7 +293,7 @@
     <section class="line-cta" aria-label="LINEで問い合わせる">
       {% if building.detail_mode in ["sale", "both"] %}
       <h2>お問い合わせ</h2>
-      {% if (building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0 %}
+      {% if (building.sale_listing_count or 0) > 0 %}
       <p>この建物の売出し状況にあわせて、購入と売却の相談を受け付けています。</p>
       {% else %}
       <p>現在の売出しがない建物でも、売却査定のご相談を受け付けています。</p>
@@ -305,7 +309,7 @@
             <a class="button" href="{{ line_cta_url }}" target="_blank" rel="noopener">この建物の購入相談をする</a>
             <a class="button" href="{{ line_cta_url }}" target="_blank" rel="noopener">この建物の売却査定をする</a>
           {% elif building.detail_mode == "sale" %}
-            {% if (building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0 %}
+            {% if (building.sale_listing_count or 0) > 0 %}
               <a class="button button--line" href="{{ line_cta_url }}" target="_blank" rel="noopener">この建物の購入相談をする</a>
               <a class="button" href="{{ line_cta_url }}" target="_blank" rel="noopener">この建物の売却査定をする</a>
             {% else %}

--- a/templates_v2/building.html.j2
+++ b/templates_v2/building.html.j2
@@ -113,13 +113,14 @@
   <section class="info card mode-panel" aria-label="販売状況" data-mode-panel="sale" {% if is_both_mode %}hidden{% endif %}>
     <h2 class="a11y-only">販売状況</h2>
     <dl class="facts">
-      <div class="fact-row{% if not ((building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0) %} fact-row--single{% endif %}">
+      <div class="fact-row{% if not ((building.sale_listing_count or 0) > 0) %} fact-row--single{% endif %}">
         <div class="fact"><dt>販売状況</dt><dd>{{ building.sale_status_label }}</dd></div>
-        {% if (building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0 %}
+        {% if (building.sale_listing_count or 0) > 0 %}
         <div class="fact"><dt>価格</dt><dd>{{ building.sale_price_label or "販売中" }}</dd></div>
         {% endif %}
       </div>
-      {% if (building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0 %}
+      {% if (building.sale_listing_count or 0) > 0 %}
+      {% if building.sale_floor_label or building.sale_direction_label %}
       <div class="fact-row{% if not (building.sale_floor_label and building.sale_direction_label) %} fact-row--single{% endif %}">
         {% if building.sale_floor_label %}
         <div class="fact"><dt>所在階</dt><dd>{{ building.sale_floor_label }}</dd></div>
@@ -128,6 +129,8 @@
         <div class="fact"><dt>向き</dt><dd>{{ building.sale_direction_label }}</dd></div>
         {% endif %}
       </div>
+      {% endif %}
+      {% if building.sale_layout_label or building.sale_area_label %}
       <div class="fact-row{% if not (building.sale_layout_label and building.sale_area_label) %} fact-row--single{% endif %}">
         {% if building.sale_layout_label %}
         <div class="fact"><dt>間取り</dt><dd>{{ building.sale_layout_label }}</dd></div>
@@ -136,6 +139,7 @@
         <div class="fact"><dt>面積</dt><dd>{{ building.sale_area_label }}</dd></div>
         {% endif %}
       </div>
+      {% endif %}
       {% if building.sale_sqm_price_label %}
       <div class="fact-row fact-row--single">
         <div class="fact fact--wide"><dt>㎡単価</dt><dd>{{ building.sale_sqm_price_label }}</dd></div>
@@ -163,7 +167,7 @@
   </section>
 
   <section class="line-cta card{% if is_both_mode %} mode-panel{% endif %}" aria-label="分譲のお問い合わせ" {% if is_both_mode %}data-mode-panel="sale" hidden{% endif %}>
-    {% if (building.sale_summary and (building.sale_summary.sale_listing_count or 0) > 0) or (building.sale_listing_count or 0) > 0 %}
+    {% if (building.sale_listing_count or 0) > 0 %}
     <a class="button button--line" href="{{ line_cta_url }}" target="_blank" rel="noopener" data-line-universal-url="{{ line_cta_url }}" data-line-deep-link="{{ line_deep_link_url }}" onclick="(function(event){var link=event.currentTarget;var deepLink=link.dataset.lineDeepLink;var fallback=link.dataset.lineUniversalUrl;setTimeout(function(){window.location.href=fallback;},700);window.location.href=deepLink;})(event)">この建物の購入相談をする</a>
     <a class="button" href="{{ line_cta_url }}" target="_blank" rel="noopener">この建物の売却査定をする</a>
     {% else %}


### PR DESCRIPTION
### Motivation
- 分譲カードが単一代表行に依存しており、複数販売住戸で価格/間取り/面積/㎡単価が単一値になる問題を解消するため。
- 一覧と詳細で値源が揺れて不整合になるケース（visible/current の不一致）を同一ロジックで揃えるため。
- 所在階/向き双方が空のときに空段が残る表示を消すため。

### Description
- `src/tatemono_map/normalize/building_summaries.py` の集約ロジックを修正し、`sale_listings` から価格・面積を min/max、間取り/所在階/向きは distinct（自然順ソート）で生成するように変更しました。
- `src/tatemono_map/render/build.py` に current sale の field-level 集約 (`listing_count`, `price_min`/`price_max`, `area_min`/`area_max`, `sqm_price_min`/`sqm_price_max`, `layout_list`, `floor_list`, `direction_list`) を追加し、一覧/詳細描画で同一 aggregate を値源として上書きするようにしました。
- テンプレート `templates/building.html.j2` / `templates_v2/building.html.j2` を最小変更し、`building.sale_listing_count` を販売有無判定に使うようにし、所在階/向き が両方空の行や 間取り/面積 が両方空の行を丸ごと非表示にする条件を追加しました。
- 重複除去と自然順ソートのヘルパーを追加し、`2LDK, 3LDK` のような並びを安定化させました。
- 変更ファイル: `src/tatemono_map/normalize/building_summaries.py`, `src/tatemono_map/render/build.py`, `templates/building.html.j2`, `templates_v2/building.html.j2`。

### Testing
- `python -m compileall` を実行し対象モジュールのコンパイルは成功しました。 (success)
- `PYTHONPATH=src python -m tatemono_map.normalize.building_summaries --db-path data/tatemono_map.sqlite3` を実行して summary 再生成は実行されましたが、テストDB は空のため対象6物件の実データ検証は行えませんでした. (ran, DB empty)
- 統合テストとして `PYTHONPATH=.:src pytest -q` を実行した結果、165件通過・4件スキップの一方で7件が失敗しました; 失敗した主要テストは以下です: `test_sale_summary_generated_from_bunjo_facts_without_sale_listing_count`, `test_sale_summary_uses_sale_listings_payload`, `test_ingest_building_facts_updates_bunjo_fields`, `test_merge_duplicate_buildings_noop_on_ambiguous_case`, `test_render_dist_sanitizes_room_number_from_name_and_address`, `test_render_dist_sale_section_shows_sqm_floor_and_direction`, `test_build_dist_versions_outputs_v2_min_json_with_contract`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dba770f5688326ba58ad42d04bd93a)