### PR TITLE
Fix sale summary alias fallback and suppress duplicate buildings in render

### DIFF
--- a/src/tatemono_map/render/build.py
+++ b/src/tatemono_map/render/build.py
@@ -16,6 +16,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from tatemono_map.db.repo import connect
 from tatemono_map.util.building_age import age_years_from_built_year_month
+from tatemono_map.util.text import normalize_text
 
 FORBIDDEN_PATTERNS = (
     r"mail=",
@@ -273,6 +274,40 @@ def _sanitize_building(building: dict) -> dict:
         elif isinstance(value, list):
             sanitized[key] = [_sanitize_text(item) if isinstance(item, str) else item for item in value]
     return sanitized
+
+
+def _dedupe_building_key(building: dict) -> tuple[str, str]:
+    norm_name = normalize_text(str(building.get("norm_name") or "")) or normalize_text(str(building.get("name") or ""))
+    norm_address = normalize_text(str(building.get("norm_address") or "")) or normalize_text(str(building.get("address") or ""))
+    return (norm_name.lower(), norm_address.lower())
+
+
+def _building_information_score(building: dict) -> tuple[int, int]:
+    sale_summary = building.get("sale_summary") or {}
+    rental_summary = building.get("rental_summary") or {}
+    sale_current = building.get("sale_current") or {}
+    rental_current = building.get("rental_current") or {}
+    score = 0
+    for key in (
+        "address",
+        "access_info",
+        "building_structure",
+        "structure",
+        "building_built_year_month",
+        "building_built_age_years",
+    ):
+        if building.get(key):
+            score += 1
+    score += int(building.get("vacancy_count") or 0)
+    score += int(building.get("has_rental") or 0)
+    score += int(building.get("has_sale") or 0)
+    score += int(rental_summary.get("vacancy_count") or 0)
+    score += int(sale_summary.get("sale_listing_count") or 0)
+    score += int(sale_current.get("listing_count") or 0)
+    score += len(rental_current.get("rents") or [])
+    score += len(rental_current.get("layouts") or [])
+    score += len(sale_current.get("layout_list") or [])
+    return (score, int(building.get("updated_epoch") or -1))
 
 
 def _to_ascii_digits(value: str) -> str:
@@ -850,6 +885,8 @@ def _load_buildings(db_path: str) -> tuple[list[dict], int, int, int, int]:
             b.floor_count_text,
             b.total_units,
             b.management_style,
+            b.norm_name,
+            b.norm_address,
             COALESCE(s.updated_at, b.updated_at) AS updated_at
         FROM building_summaries s
         LEFT JOIN buildings b ON b.building_id = s.building_key
@@ -888,6 +925,8 @@ def _load_buildings(db_path: str) -> tuple[list[dict], int, int, int, int]:
             b.floor_count_text,
             b.total_units,
             b.management_style,
+            b.norm_name,
+            b.norm_address,
             b.updated_at AS updated_at
         FROM buildings b
         WHERE COALESCE(b.hidden_from_public, 0) = 0
@@ -1055,14 +1094,26 @@ def _load_buildings(db_path: str) -> tuple[list[dict], int, int, int, int]:
     sale_summary_map = merged_sale_summary_map
     conn.close()
     for building in building_list:
+        building_key = str(building.get("building_key"))
+        canonical_key = alias_map.get(building_key, building_key)
         building["sponsor"] = sponsor_map.get(str(building.get("building_key")))
-        building["rental_summary"] = rental_summary_map.get(str(building.get("building_key")))
-        building["sale_summary"] = sale_summary_map.get(str(building.get("building_key")))
-        rental_terms = rental_terms_map.get(str(building.get("building_key")), {"deposit": [], "key_money": []})
+        building["rental_summary"] = rental_summary_map.get(canonical_key) or rental_summary_map.get(building_key)
+        building["sale_summary"] = sale_summary_map.get(canonical_key) or sale_summary_map.get(building_key)
+        rental_terms = rental_terms_map.get(canonical_key) or rental_terms_map.get(building_key) or {"deposit": [], "key_money": []}
         building["rental_deposit_label"] = _format_text_label(rental_terms.get("deposit", []))
         building["rental_key_money_label"] = _format_text_label(rental_terms.get("key_money", []))
-        building["rental_current"] = rental_current_map.get(str(building.get("building_key")), {})
-        building["sale_current"] = sale_current_map.get(str(building.get("building_key")), {})
+        building["rental_current"] = rental_current_map.get(canonical_key) or rental_current_map.get(building_key) or {}
+        building["sale_current"] = sale_current_map.get(canonical_key) or sale_current_map.get(building_key) or {}
+
+    deduped_buildings: dict[tuple[str, str], dict] = {}
+    for building in building_list:
+        dedupe_key = _dedupe_building_key(building)
+        if not dedupe_key[0] and not dedupe_key[1]:
+            dedupe_key = (str(building.get("building_key") or ""), "")
+        current = deduped_buildings.get(dedupe_key)
+        if current is None or _building_information_score(building) > _building_information_score(current):
+            deduped_buildings[dedupe_key] = building
+    building_list = list(deduped_buildings.values())
     print(
         "render_kpi_counts canonical_buildings_count={} summary_buildings_count={} vacancy_total={}".format(
             canonical_buildings_count,
@@ -1387,11 +1438,15 @@ def _build_dist_version(
         b["access_info"] = _format_access_info_for_display(b.get("access_info"))
         b["display_structure"] = _normalize_structure_label(b.get("building_structure") or b.get("structure"))
         sale_current = b.get("sale_current") or {}
-        sale_count = int(sale_current.get("listing_count") or 0)
+        sale_count = int(sale_current.get("listing_count") or sale_summary.get("sale_listing_count") or 0)
         b["sale_listing_count"] = sale_count
         b["sale_status_label"] = f"{sale_count}件" if sale_count > 0 else "現在、販売中の住戸はありません。"
         sale_price_min = sale_current.get("price_min")
+        if sale_price_min is None:
+            sale_price_min = sale_summary.get("price_yen_min")
         sale_price_max = sale_current.get("price_max")
+        if sale_price_max is None:
+            sale_price_max = sale_summary.get("price_yen_max")
         b["sale_price_yen_min"] = sale_price_min
         b["sale_price_yen_max"] = sale_price_max
         b["sale_price_yen_avg"] = int((sale_price_min + sale_price_max) / 2) if sale_price_min is not None and sale_price_max is not None else None
@@ -1401,7 +1456,11 @@ def _build_dist_version(
             suffix="万円",
         )
         sale_area_min = sale_current.get("area_min")
+        if sale_area_min is None:
+            sale_area_min = sale_summary.get("area_sqm_min")
         sale_area_max = sale_current.get("area_max")
+        if sale_area_max is None:
+            sale_area_max = sale_summary.get("area_sqm_max")
         b["sale_area_sqm_min"] = sale_area_min
         b["sale_area_sqm_max"] = sale_area_max
         b["sale_area_label"] = _format_range(
@@ -1409,16 +1468,20 @@ def _build_dist_version(
             sale_area_max,
             suffix="㎡",
         )
-        b["sale_layout_label"] = _format_layout_label(sale_current.get("layout_list") or [])
+        b["sale_layout_label"] = _format_layout_label(sale_current.get("layout_list") or (json.loads(sale_summary.get("layout_types_json") or "[]") if sale_summary else []))
         sqm_price_min = sale_current.get("sqm_price_min")
+        if sqm_price_min is None:
+            sqm_price_min = sale_summary.get("tsubo_unit_price_yen_min")
         sqm_price_max = sale_current.get("sqm_price_max")
+        if sqm_price_max is None:
+            sqm_price_max = sale_summary.get("tsubo_unit_price_yen_max")
         b["sale_sqm_price_label"] = _format_range(
             (sqm_price_min / 10000) if sqm_price_min is not None else None,
             (sqm_price_max / 10000) if sqm_price_max is not None else None,
             suffix="万円/㎡",
         )
-        b["sale_floor_label"] = _format_text_label(sale_current.get("floor_list") or [])
-        b["sale_direction_label"] = _format_text_label(sale_current.get("direction_list") or [])
+        b["sale_floor_label"] = _format_text_label(sale_current.get("floor_list") or [sale_summary.get("floor_summary")])
+        b["sale_direction_label"] = _format_text_label(sale_current.get("direction_list") or [sale_summary.get("direction_summary")])
         seo = _build_building_seo(b, site_origin=site_origin, base_path=base_path)
         detail_path = f"{base_path}/b/{b['detail_filename']}"
         area_hub = None

--- a/tests/test_render_dist.py
+++ b/tests/test_render_dist.py
@@ -8,7 +8,7 @@ from tatemono_map.db.keys import make_building_key
 from tatemono_map.db.repo import ListingRecord, connect, upsert_listing
 from tatemono_map.normalize.building_summaries import rebuild
 from tatemono_map.render.build import build_dist, build_dist_versions
-from tatemono_map.render.build import _sort_area_buildings
+from tatemono_map.render.build import _load_buildings, _sort_area_buildings
 
 
 def _pick_primary_detail_path(detail_dir: Path) -> Path:
@@ -142,6 +142,63 @@ def test_render_dist_sale_section_shows_sqm_floor_and_direction(tmp_path):
     assert "所在階" in detail
     assert "7階" in detail
     assert "向き" in detail
+    assert "南" in detail
+
+
+def test_render_dist_sale_summary_alias_fallback_and_duplicate_suppression(tmp_path):
+    db = tmp_path / "test_sale_alias.sqlite3"
+    dist = tmp_path / "dist"
+    conn = connect(db)
+    conn.execute(
+        """
+        INSERT INTO buildings(building_id, canonical_name, canonical_address, norm_name, norm_address, updated_at)
+        VALUES
+            ('kokura-empty', '小倉ＤＣタワー', '福岡県北九州市小倉北区浅野1-1-1', '小倉dcタワー', '北九州市小倉北区浅野1-1-1', '2026-04-01'),
+            ('kokura-rich', '小倉ＤＣタワー', '福岡県北九州市小倉北区浅野1-1-1', '小倉dcタワー', '北九州市小倉北区浅野1-1-1', '2026-04-02')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO building_summaries(building_key, name, raw_name, address, has_sale, updated_at)
+        VALUES
+            ('kokura-empty', '小倉ＤＣタワー', '小倉ＤＣタワー', '福岡県北九州市小倉北区浅野1-1-1', 0, '2026-04-01'),
+            ('kokura-rich', '小倉ＤＣタワー', '小倉ＤＣタワー', '福岡県北九州市小倉北区浅野1-1-1', 1, '2026-04-02')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO building_key_aliases(alias_key, canonical_key, updated_at)
+        VALUES ('mr-alias-kokura', 'kokura-rich', '2026-04-02')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO building_sale_summaries(
+            building_key, sale_listing_count, price_yen_min, price_yen_max,
+            tsubo_unit_price_yen_min, tsubo_unit_price_yen_max, area_sqm_min, area_sqm_max,
+            layout_types_json, floor_summary, direction_summary, updated_at
+        ) VALUES (
+            'mr-alias-kokura', 1, 39800000, 39800000,
+            549000, 549000, 72.5, 72.5, '["3LDK"]', '7階', '南', '2026-04-02'
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    buildings, *_ = _load_buildings(str(db))
+    assert len([b for b in buildings if b["name"] == "小倉ＤＣタワー"]) == 1
+    kokura = next(b for b in buildings if b["name"] == "小倉ＤＣタワー")
+    assert kokura["building_key"] == "kokura-rich"
+    assert (kokura.get("sale_summary") or {}).get("sale_listing_count") == 1
+
+    build_dist(str(db), str(dist))
+    detail_path = next((dist / "b").glob("*-kokura-rich.html"))
+    detail = detail_path.read_text(encoding="utf-8")
+    assert "1件" in detail
+    assert "3,980万円" in detail
+    assert "54.9万円/㎡" in detail
+    assert "7階" in detail
     assert "南" in detail
 
 


### PR DESCRIPTION
### Motivation
- Fix rendering bugs causing duplicate buildings and missing sale data when sale summaries exist only on alias keys, without touching UI/templates/deploy or doing large DB/parser redesigns. 
- Ensure canonical detail pages pick up `building_sale_summaries` (alias→canonical) when `sale_listings` are absent and avoid outputting stale/near-empty duplicate rows. 

### Description
- Add fallback lookup so `sale_summary` and `rental_summary` are resolved by `alias_map` first and then by the building row key, enabling alias-only `building_sale_summaries` to appear on canonical detail pages (`_load_buildings` changes and attachment logic). 
- Add fallbacks in `_build_dist_version` to use `sale_summary` values for price/area/㎡単価/間取り/所在階/向き when `sale_current` (live `sale_listings`) is empty. 
- Add minimal render-side duplicate suppression keyed by normalized `norm_name`/`norm_address` with a lightweight information-scoring comparator (`_dedupe_building_key`, `_building_information_score`) that keeps the richer/staler-avoiding row and excludes near-empty stale rows from `dist` and `buildings.json`. 
- Include `norm_name`/`norm_address` in the building row selection (no DB schema changes, just reading existing columns) and keep rental summary behavior unchanged. 
- Files changed: `src/tatemono_map/render/build.py` and `tests/test_render_dist.py` (added `test_render_dist_sale_summary_alias_fallback_and_duplicate_suppression`). 

### Testing
- Ran `pytest -q tests/test_render_dist.py -k 'sale_summary_alias_fallback_and_duplicate_suppression'` and it passed. 
- Ran `pytest -q tests/test_render_dist.py -k 'render_dist_outputs or sale_summary_alias_fallback_and_duplicate_suppression'` and the selected tests passed. 
- The new regression test verifies that duplicate Kokura DC Tower-like rows collapse to one output, the richer canonical row is kept, and alias-only `sale_summary` data is visible on the canonical detail page.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf07300cc83269a6684b6a3c6ea43)