### PR TITLE
一覧カードで分譲の面積/価格表示を sale の min/max を優先するよう修正

### DIFF
--- a/templates_v2/area.html.j2
+++ b/templates_v2/area.html.j2
@@ -68,7 +68,9 @@
             <li class="kpi"><span>販売情報</span>{{ b.sale_listing_count if b.sale_listing_count is not none and b.sale_listing_count > 0 else "なし" }}</li>
           {% elif b.listing_mode == "sale" %}
             <li class="kpi"><span>販売情報</span>{{ b.sale_listing_count if b.sale_listing_count is not none and b.sale_listing_count > 0 else "なし" }}</li>
-            <li class="kpi"><span>家賃</span>{{ ((b.sale_price_yen_avg / 10000)|int ~ "万円") if b.sale_price_yen_avg is not none else "—" }}</li>
+            {% set sale_price_min = b.sale_price_yen_min if b.sale_price_yen_min is not none and b.sale_price_yen_min > 0 else none %}
+            {% set sale_price_max = b.sale_price_yen_max if b.sale_price_yen_max is not none and b.sale_price_yen_max > 0 else none %}
+            <li class="kpi"><span>販売価格</span>{% if sale_price_min and sale_price_max %}{% if sale_price_min == sale_price_max %}{{ ((sale_price_min / 10000)|int) }}万円{% else %}{{ ((sale_price_min / 10000)|int) }}万円〜{{ ((sale_price_max / 10000)|int) }}万円{% endif %}{% elif sale_price_min %}{{ ((sale_price_min / 10000)|int) }}万円{% elif sale_price_max %}{{ ((sale_price_max / 10000)|int) }}万円{% else %}—{% endif %}</li>
           {% else %}
             <li class="kpi"><span>空室</span>{{ b.vacancy_count if b.vacancy_count is not none else "—" }}件</li>
             {% set rent_min = b.rent_yen_min if b.rent_yen_min is not none and b.rent_yen_min > 0 else none %}
@@ -76,8 +78,10 @@
             <li class="kpi"><span>家賃</span>{% if rent_min and rent_max %}{% if rent_min == rent_max %}{{ rent_min|yen }}円{% else %}{{ rent_min|yen }}円〜{{ rent_max|yen }}円{% endif %}{% elif rent_min %}{{ rent_min|yen }}円{% elif rent_max %}{{ rent_max|yen }}円{% else %}—{% endif %}</li>
           {% endif %}
         </ul>
-        {% set area_min = b.area_sqm_min if b.area_sqm_min is not none and b.area_sqm_min > 0 else none %}
-        {% set area_max = b.area_sqm_max if b.area_sqm_max is not none and b.area_sqm_max > 0 else none %}
+        {% set area_min = (b.sale_area_sqm_min if b.sale_area_sqm_min is not none and b.sale_area_sqm_min > 0 else none) if b.listing_mode in ["sale", "both"] or b.property_kind == "bunjo" else (b.area_sqm_min if b.area_sqm_min is not none and b.area_sqm_min > 0 else none) %}
+        {% set area_max = (b.sale_area_sqm_max if b.sale_area_sqm_max is not none and b.sale_area_sqm_max > 0 else none) if b.listing_mode in ["sale", "both"] or b.property_kind == "bunjo" else (b.area_sqm_max if b.area_sqm_max is not none and b.area_sqm_max > 0 else none) %}
+        {% if area_min is none %}{% set area_min = b.area_sqm_min if b.area_sqm_min is not none and b.area_sqm_min > 0 else none %}{% endif %}
+        {% if area_max is none %}{% set area_max = b.area_sqm_max if b.area_sqm_max is not none and b.area_sqm_max > 0 else none %}{% endif %}
         <dl class="meta">
           <div class="meta-row">
             <dt>面積</dt>

--- a/templates_v2/index.html.j2
+++ b/templates_v2/index.html.j2
@@ -164,7 +164,9 @@
             <li class="kpi"><span>販売情報</span>{% if b.sale_listing_count is not none and b.sale_listing_count > 0 %}{{ b.sale_listing_count }}件{% else %}なし{% endif %}</li>
           {% elif b.listing_mode == "sale" %}
             <li class="kpi"><span>販売情報</span>{% if b.sale_listing_count is not none and b.sale_listing_count > 0 %}{{ b.sale_listing_count }}件{% else %}なし{% endif %}</li>
-            <li class="kpi"><span>販売価格</span>{{ ((b.sale_price_yen_avg / 10000)|int ~ "万円") if b.sale_price_yen_avg is not none else "—" }}</li>
+            {% set sale_price_min = b.sale_price_yen_min if b.sale_price_yen_min is not none and b.sale_price_yen_min > 0 else none %}
+            {% set sale_price_max = b.sale_price_yen_max if b.sale_price_yen_max is not none and b.sale_price_yen_max > 0 else none %}
+            <li class="kpi"><span>販売価格</span>{% if sale_price_min and sale_price_max %}{% if sale_price_min == sale_price_max %}{{ ((sale_price_min / 10000)|int) }}万円{% else %}{{ ((sale_price_min / 10000)|int) }}万円〜{{ ((sale_price_max / 10000)|int) }}万円{% endif %}{% elif sale_price_min %}{{ ((sale_price_min / 10000)|int) }}万円{% elif sale_price_max %}{{ ((sale_price_max / 10000)|int) }}万円{% else %}—{% endif %}</li>
           {% else %}
             <li class="kpi"><span>空室</span>{{ b.vacancy_count if b.vacancy_count is not none else "—" }}件</li>
             {% set rent_min = b.rent_yen_min if b.rent_yen_min is not none and b.rent_yen_min > 0 else none %}
@@ -172,8 +174,10 @@
             <li class="kpi"><span>家賃</span>{% if rent_min and rent_max %}{% if rent_min == rent_max %}{{ rent_min|yen }}円{% else %}{{ rent_min|yen }}円〜{{ rent_max|yen }}円{% endif %}{% elif rent_min %}{{ rent_min|yen }}円{% elif rent_max %}{{ rent_max|yen }}円{% else %}—{% endif %}</li>
           {% endif %}
         </ul>
-        {% set area_min = b.area_sqm_min if b.area_sqm_min is not none and b.area_sqm_min > 0 else none %}
-        {% set area_max = b.area_sqm_max if b.area_sqm_max is not none and b.area_sqm_max > 0 else none %}
+        {% set area_min = (b.sale_area_sqm_min if b.sale_area_sqm_min is not none and b.sale_area_sqm_min > 0 else none) if b.listing_mode in ["sale", "both"] or b.property_kind == "bunjo" else (b.area_sqm_min if b.area_sqm_min is not none and b.area_sqm_min > 0 else none) %}
+        {% set area_max = (b.sale_area_sqm_max if b.sale_area_sqm_max is not none and b.sale_area_sqm_max > 0 else none) if b.listing_mode in ["sale", "both"] or b.property_kind == "bunjo" else (b.area_sqm_max if b.area_sqm_max is not none and b.area_sqm_max > 0 else none) %}
+        {% if area_min is none %}{% set area_min = b.area_sqm_min if b.area_sqm_min is not none and b.area_sqm_min > 0 else none %}{% endif %}
+        {% if area_max is none %}{% set area_max = b.area_sqm_max if b.area_sqm_max is not none and b.area_sqm_max > 0 else none %}{% endif %}
         <dl class="meta">
           <div class="meta-row">
             <dt>面積</dt>
@@ -367,7 +371,7 @@
       rentKpi.innerHTML = `<span>販売情報</span>${Number.isFinite(Number(item.saleListingCount)) && Number(item.saleListingCount) > 0 ? `${Number(item.saleListingCount)}件` : 'なし'}`;
     } else if (isSale) {
       vacancyKpi.innerHTML = `<span>販売情報</span>${Number.isFinite(Number(item.saleListingCount)) && Number(item.saleListingCount) > 0 ? `${Number(item.saleListingCount)}件` : 'なし'}`;
-      rentKpi.innerHTML = `<span>販売価格</span>${Number.isFinite(Number(item.salePriceAvg)) ? `${formatCount(Math.floor(Number(item.salePriceAvg) / 10000))}万円` : '—'}`;
+      rentKpi.innerHTML = `<span>販売価格</span>${formatRangeLabel(item.salePriceMin, item.salePriceMax, (n) => `${formatCount(Math.floor(n / 10000))}万円`)}`;
     } else {
       vacancyKpi.innerHTML = `<span>空室</span>${Number.isFinite(Number(item.vacancyCount)) ? Number(item.vacancyCount) : '—'}件`;
       rentKpi.innerHTML = `<span>家賃</span>${formatRangeLabel(item.rentMin, item.rentMax, (n) => formatYen(n))}`;
@@ -378,7 +382,10 @@
     meta.className = 'meta';
     const areaRow = document.createElement('div');
     areaRow.className = 'meta-row';
-    areaRow.innerHTML = `<dt>面積</dt><dd>${formatRangeLabel(item.areaMin, item.areaMax, (n) => formatArea(n))}</dd>`;
+    const isSaleLike = isSale || isBoth || item.propertyKind === 'bunjo';
+    const areaMin = isSaleLike && item.saleAreaMin != null ? item.saleAreaMin : item.areaMin;
+    const areaMax = isSaleLike && item.saleAreaMax != null ? item.saleAreaMax : item.areaMax;
+    areaRow.innerHTML = `<dt>面積</dt><dd>${formatRangeLabel(areaMin, areaMax, (n) => formatArea(n))}</dd>`;
     const updatedRow = document.createElement('div');
     updatedRow.className = 'meta-row';
     updatedRow.innerHTML = `<dt>建物構造</dt><dd>${item.buildingStructure || '—'}</dd>`;
@@ -621,12 +628,16 @@
           address: item.address || '',
           propertyKind: item.property_kind || '',
           listingMode,
+          salePriceMin: item.sale_price_min,
+          salePriceMax: item.sale_price_max,
           salePriceAvg: item.sale_price_avg,
           saleListingCount: item.sale_listing_count,
           vacancyCount: safeNumber(item.vacancy_count, 0),
           vacancyCountSafe: Math.max(0, safeNumber(item.vacancy_count, 0)),
           rentMin: item.rent_min,
           rentMax: item.rent_max,
+          saleAreaMin: item.sale_area_min,
+          saleAreaMax: item.sale_area_max,
           areaMin: item.area_min,
           areaMax: item.area_max,
           updatedAt: item.updated_at || '',

--- a/tests/test_render_dist.py
+++ b/tests/test_render_dist.py
@@ -547,6 +547,28 @@ def test_build_dist_versions_v2_index_has_min_json_fallback_logic(tmp_path):
     assert "function validateRawItems(raw, sourceLabel)" in index_v2
 
 
+def test_build_dist_versions_v2_index_sale_card_uses_sale_min_max_fields(tmp_path):
+    db = tmp_path / "test.sqlite3"
+    out = tmp_path / "dist"
+    conn = connect(db)
+    upsert_listing(
+        conn,
+        ListingRecord("分譲表示確認マンション", "東京都港区1-2-3", 120000, 31.0, "1LDK", "2026-12-01", "ulucks", "sale-card-check"),
+    )
+    conn.close()
+
+    rebuild(str(db))
+    build_dist_versions(str(db), str(out))
+
+    index_v2 = (out / "index.html").read_text(encoding="utf-8")
+    assert "salePriceMin: item.sale_price_min" in index_v2
+    assert "salePriceMax: item.sale_price_max" in index_v2
+    assert "saleAreaMin: item.sale_area_min" in index_v2
+    assert "saleAreaMax: item.sale_area_max" in index_v2
+    assert "formatRangeLabel(item.salePriceMin, item.salePriceMax" in index_v2
+    assert "item.saleAreaMin != null ? item.saleAreaMin : item.areaMin" in index_v2
+
+
 def test_render_dist_versions_detail_shows_immediate_when_availability_label_is_nyukyo(tmp_path):
     db = tmp_path / "test.sqlite3"
     out = tmp_path / "dist"


### PR DESCRIPTION
### Motivation
- 一覧ページの分譲カードで面積が詳細と異なり「—」になる問題を修正するために、一覧で `areaMin/areaMax` ではなく分譲向けの `saleAreaMin/saleAreaMax` を優先して使う必要がある。 
- 分譲の一覧カードで価格が `salePriceAvg` の単値表示になっているため、複数住戸がある場合は `salePriceMin/salePriceMax` の範囲表示にする必要がある。

### Description
- v2 の動的カード（`templates_v2/index.html.j2` のクライアント描画）で、価格表示を `salePriceAvg` から `salePriceMin`/`salePriceMax` の範囲表示に変更し、`min == max` の場合は単値表示となるようにした。 
- v2 の動的カードで面積は `listing_mode` が `sale`/`both` か `property_kind == 'bunjo'` の場合に `saleAreaMin/saleAreaMax` を優先し、存在しない場合のみ既存の `areaMin/areaMax` にフォールバックするようにした。 
- 同じ最小差分ロジックをサーバーサイドで出力する静的テンプレート部分（`templates_v2/index.html.j2` の静的ループと `templates_v2/area.html.j2`）にも適用し、一覧カード構造やスタイルは変更していない。 
- 変更ファイル: `templates_v2/index.html.j2`, `templates_v2/area.html.j2`, `tests/test_render_dist.py`（v2 テンプレートが新しいフィールドを使うことを確認するテストを追加）。

### Testing
- 実行した単体テスト: `pytest -q tests/test_render_dist.py -k "sale_card_uses_sale_min_max_fields"` は成功（新規追加の検証テストが通過）。
- 追加で部分的に実行した: `pytest -q tests/test_render_dist.py -k "outputs_buildings_json_keys or sale_section_shows_sqm_floor_and_direction"` は既存の詳細ページ周りの別のテストで失敗しており、今回の一覧カード修正範囲とは無関係な既存の期待値差（詳細ページの㎡単価表示）によるものだった。 
- 変更は一覧カードの表示ロジックのみで、詳細ページ・正規化処理・パーサ・ビルドスクリプト・ワークフロー等には触れていないことを確認済み。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc023eba4c832686cdc536bcf2c6c5)