### PR TITLE
Guard mansion direction fallback and suppress inconsistent single-price sale fallback

### DIFF
--- a/scripts/mansion_review_crawl_to_csv.py
+++ b/scripts/mansion_review_crawl_to_csv.py
@@ -423,7 +423,7 @@ def _extract_mansion_row(cols: dict[str, str], cells: list[dict[str, str]], buil
             if not floor and ("所在階" in label or _is_floor_text(text)):
                 floor = text
                 continue
-            if not direction and ("向き" in label or _is_direction_text(text)):
+            if not direction and _is_direction_text(text):
                 direction = text
                 continue
             if not price and ("価格" in label or ("販売価格" in label) or (_is_money_text(text) and not _is_tsubo_text(text))):

--- a/src/tatemono_map/normalize/building_summaries.py
+++ b/src/tatemono_map/normalize/building_summaries.py
@@ -367,6 +367,16 @@ def rebuild(db_path: str) -> int:
             else (building["sale_layout_types_json"] if building else None)
         )
         sale_listing_count = len(sale_items) if sale_items else (building["sale_listing_count"] if building else None)
+        if (
+            not sale_prices
+            and (sale_listing_count or 0) > 1
+            and sale_price_min is not None
+            and sale_price_max is not None
+            and sale_price_min == sale_price_max
+        ):
+            sale_price_min = None
+            sale_price_max = None
+            sale_price_avg = None
 
         availability_label = (_select_availability_label(move_in_dates, items) if items else None) or fallback_availability_label
         vacancy_count = len(items)

--- a/tests/test_building_summaries.py
+++ b/tests/test_building_summaries.py
@@ -505,3 +505,39 @@ def test_sale_summary_uses_sale_listings_payload(tmp_path):
     assert sale_summary["direction_summary"] == "南, 東"
     assert sale_summary["floor_count_text"] == "14階建"
     assert sale_summary["total_units"] == 120
+
+
+def test_sale_summary_hides_single_price_fallback_when_count_is_plural_without_sale_listings(tmp_path):
+    db = tmp_path / "test_sale_summary_plural_count_single_price_fallback.sqlite3"
+    conn = connect(db)
+    conn.execute(
+        """
+        INSERT INTO buildings(
+            building_id, canonical_name, canonical_address, property_kind,
+            sale_price_yen_min, sale_price_yen_max, sale_price_yen_avg,
+            sale_area_sqm_min, sale_area_sqm_max, sale_layout_types_json, sale_listing_count
+        ) VALUES ('b-sale','分譲マンション','福岡県北九州市門司区X','bunjo',29800000,29800000,29800000,55.0,55.0,'["2LDK"]',3)
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    rebuild(str(db))
+
+    conn = connect(db)
+    summary = conn.execute(
+        "SELECT sale_listing_count, sale_price_yen_min, sale_price_yen_max, sale_price_yen_avg, has_sale FROM building_summaries WHERE building_key='b-sale'"
+    ).fetchone()
+    sale_summary = conn.execute(
+        "SELECT sale_listing_count, price_yen_min, price_yen_max FROM building_sale_summaries WHERE building_key='b-sale'"
+    ).fetchone()
+    conn.close()
+
+    assert summary["has_sale"] == 1
+    assert summary["sale_listing_count"] == 3
+    assert summary["sale_price_yen_min"] is None
+    assert summary["sale_price_yen_max"] is None
+    assert summary["sale_price_yen_avg"] is None
+    assert sale_summary["sale_listing_count"] == 3
+    assert sale_summary["price_yen_min"] is None
+    assert sale_summary["price_yen_max"] is None

--- a/tests/test_mansion_review_crawl_to_csv.py
+++ b/tests/test_mansion_review_crawl_to_csv.py
@@ -176,6 +176,37 @@ def test_parse_list_page_mansion_ignores_leading_decorative_cells() -> None:
     assert row.direction_text == "南"
 
 
+def test_parse_list_page_mansion_does_not_treat_layout_as_direction_on_shifted_column() -> None:
+    html = """
+    <html><body>
+      <article class="property-detail-list-item">
+        <h3>パサージュ門司</h3>
+        <div class="property-detail-content_main"></div>
+        <table class="recommendTable"><tbody class="recommend_row">
+          <tr>
+            <td data-th="価格">1,980万円</td>
+            <td data-th="専有面積">41.2㎡</td>
+            <td data-th="間取り">1R</td>
+            <td data-th="所在階">5階</td>
+            <td data-th="向き">ワンルーム</td>
+          </tr>
+        </tbody></table>
+      </article>
+    </body></html>
+    """
+    rows, _ = parse_list_page(
+        html,
+        page_url="https://www.mansion-review.jp/mansion/city/1616.html",
+        kind="mansion",
+        city_id="1616",
+        page_no=1,
+    )
+    row = rows[0]
+    assert row.layout_text == "1R"
+    assert row.floor_text == "5階"
+    assert row.direction_text == ""
+
+
 def test_parse_list_page_chintai_combined_cells_are_split() -> None:
     html = """
     <html><body>


### PR DESCRIPTION
### Motivation
- Prevent layout tokens like “ワンルーム/1R/1K” from being mis-parsed into `direction` when Mansion Review list table columns are shifted.  
- Avoid misleading sale summaries where `sale_listing_count` indicates multiple units while only a single fallback price (min==max) from `buildings` is shown because `sale_listings` granular data are absent.

### Description
- Tighten Mansion Review row extraction in `scripts/mansion_review_crawl_to_csv.py` so fallback assignment into `direction_text` from table cells only accepts values that pass `_is_direction_text()` (prevents layout terms leaking into direction).  
- In `src/tatemono_map/normalize/building_summaries.py`, when there are no granular `sale_listings` prices but `sale_listing_count > 1` and the building-level fallback min==max, clear `sale_price_yen_min`, `sale_price_yen_max`, and `sale_price_yen_avg` (set to `None`) to suppress the inconsistent single-price fallback rather than inventing a range.  
- Add minimal regression tests: a crawler test that ensures a shifted-column layout term is not used as `direction`, and a summary test that ensures plural `sale_listing_count` with a singleton fallback price yields nullified price fields.  
- Changes are minimal and limited to the two requested areas; UI rendering, templates, broad parser/source-priority logic, corrections unification, and workflow/docs were not modified.

### Testing
- Ran `pytest -q tests/test_mansion_review_crawl_to_csv.py -k shifted_column` and it passed.  
- Ran `pytest -q tests/test_building_summaries.py -k single_price_fallback` and it passed.  
- A combined run including other sale-summary assertions (`pytest -q tests/test_mansion_review_crawl_to_csv.py tests/test_building_summaries.py -k 'shifted_column or plural_count_single_price_fallback or sale_summary_uses_sale_listings_payload'`) showed one unrelated failure in `test_sale_summary_uses_sale_listings_payload` due to `floor_summary` ordering (expected `"10階, 7階"` vs actual `"7階, 10階"`), which is not caused by the price fallback or direction guard changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc041bdf9883268c952cd4085f5c1a)