### PR TITLE
Prioritize latest valid sale_listings when aggregating building sale summaries

### DIFF
--- a/src/tatemono_map/normalize/building_summaries.py
+++ b/src/tatemono_map/normalize/building_summaries.py
@@ -109,6 +109,18 @@ def _distinct_natural(values: list[str]) -> list[str]:
     return sorted(deduped, key=_natural_sort_key)
 
 
+def _distinct_in_seen_order(values: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        cleaned = normalize_text(value)
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        result.append(cleaned)
+    return result
+
+
 def _normalize_sale_row_fields(row: dict) -> dict:
     normalized = dict(row)
     floor_text = normalize_text(normalized.get("floor_text"))
@@ -132,7 +144,48 @@ def _normalize_sale_row_fields(row: dict) -> dict:
             if direction_text and _SALE_LAYOUT_RE.search(direction_text):
                 normalized["direction_text"] = None
 
+    normalized_direction = normalize_text(normalized.get("direction_text"))
+    if normalized_direction and _SALE_LAYOUT_RE.search(normalized_direction):
+        normalized["direction_text"] = None
+
     return normalized
+
+
+def _is_effective_sale_item(row: dict) -> bool:
+    return any(
+        row.get(field) is not None and row.get(field) != ""
+        for field in (
+            "price_yen",
+            "area_sqm",
+            "layout",
+            "floor_text",
+            "direction_text",
+            "management_fee_yen",
+            "repair_fund_yen",
+            "sqm_unit_price_yen",
+        )
+    )
+
+
+def _filter_latest_valid_sale_items(sale_items: list[dict]) -> list[dict]:
+    normalized = [_normalize_sale_row_fields(dict(r)) for r in sale_items]
+    effective = [row for row in normalized if _is_effective_sale_item(row)]
+    if not effective:
+        return []
+
+    dated = [row for row in effective if normalize_text(row.get("updated_at"))]
+    if not dated:
+        return effective
+
+    normalized_timestamps = [normalize_text(row.get("updated_at")) or "" for row in dated]
+    distinct_timestamps = sorted(set(normalized_timestamps))
+    has_time_component = all(" " in ts for ts in distinct_timestamps if ts)
+    if not (has_time_component and len(distinct_timestamps) > 1):
+        return effective
+
+    latest_ts = distinct_timestamps[-1]
+    latest_rows = [row for row in dated if (normalize_text(row.get("updated_at")) or "") == latest_ts]
+    return latest_rows or effective
 
 
 def _nearest_availability_date(items: list) -> str | None:
@@ -345,16 +398,16 @@ def rebuild(db_path: str) -> int:
         fallback_availability_label = (normalize_text(building["availability_label"]) if building else "") or None
         fallback_property_kind = normalize_text(building["property_kind"]) if building and building["property_kind"] else ""
 
-        normalized_sale_items = [_normalize_sale_row_fields(dict(r)) for r in sale_items]
+        normalized_sale_items = _filter_latest_valid_sale_items(sale_items)
         sale_prices = [int(r["price_yen"]) for r in normalized_sale_items if r["price_yen"] is not None]
         sale_areas = [float(r["area_sqm"]) for r in normalized_sale_items if r["area_sqm"] is not None]
         sale_layouts = _distinct_natural([str(r.get("layout") or "") for r in normalized_sale_items])
         sale_mgmt_fees = [int(r["management_fee_yen"]) for r in normalized_sale_items if r["management_fee_yen"] is not None]
         sale_repair_funds = [int(r["repair_fund_yen"]) for r in normalized_sale_items if r["repair_fund_yen"] is not None]
         sale_sqm_unit_prices = [int(r["sqm_unit_price_yen"]) for r in normalized_sale_items if r["sqm_unit_price_yen"] is not None]
-        sale_floors = _distinct_natural([str(r.get("floor_text") or "") for r in normalized_sale_items])
+        sale_floors = _distinct_in_seen_order([str(r.get("floor_text") or "") for r in normalized_sale_items])
         sale_directions = _distinct_natural([str(r.get("direction_text") or "") for r in normalized_sale_items])
-        sale_latest = max((r["updated_at"] for r in sale_items if r["updated_at"]), default=None)
+        sale_latest = max((r["updated_at"] for r in normalized_sale_items if r["updated_at"]), default=None)
 
         sale_price_min = min(sale_prices) if sale_prices else (building["sale_price_yen_min"] if building else None)
         sale_price_max = max(sale_prices) if sale_prices else (building["sale_price_yen_max"] if building else None)
@@ -366,7 +419,11 @@ def rebuild(db_path: str) -> int:
             if sale_layouts
             else (building["sale_layout_types_json"] if building else None)
         )
-        sale_listing_count = len(sale_items) if sale_items else (building["sale_listing_count"] if building else None)
+        sale_listing_count = (
+            len(normalized_sale_items)
+            if normalized_sale_items
+            else (building["sale_listing_count"] if building else None)
+        )
         if (
             not sale_prices
             and (sale_listing_count or 0) > 1

--- a/tests/test_building_summaries.py
+++ b/tests/test_building_summaries.py
@@ -541,3 +541,54 @@ def test_sale_summary_hides_single_price_fallback_when_count_is_plural_without_s
     assert sale_summary["sale_listing_count"] == 3
     assert sale_summary["price_yen_min"] is None
     assert sale_summary["price_yen_max"] is None
+
+
+def test_sale_summary_uses_latest_valid_snapshot_rows_only(tmp_path):
+    db = tmp_path / "test_sale_latest_snapshot.sqlite3"
+    conn = connect(db)
+    conn.execute(
+        "INSERT INTO buildings(building_id, canonical_name, canonical_address, property_kind) VALUES ('b-sale','分譲マンション','福岡県北九州市門司区X','bunjo')"
+    )
+    conn.execute("INSERT INTO ingest_runs(id, source, snapshot_key, status) VALUES (30, 'mansion_review_mansion', 'sale-current', 'completed')")
+    conn.execute("INSERT INTO current_ingest_snapshots(source, ingest_run_id) VALUES ('mansion_review_mansion', 30)")
+    conn.executemany(
+        """
+        INSERT INTO sale_listings(
+            sale_listing_key, building_key, source, source_url, evidence_id,
+            price_yen, management_fee_yen, repair_fund_yen, tsubo_unit_price_yen, area_sqm, layout, floor_text, direction_text, updated_at, ingest_run_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            ("old-1", "b-sale", "mansion_review_mansion", "u1", "e1", 16020000, 9000, 6000, 500000, 80.16, "3LDK", "4階", "ワンルーム", "2026/04/10 16:18", 30),
+            ("new-1", "b-sale", "mansion_review_mansion", "u2", "e2", 2200000, 3000, 2000, 370000, 19.35, "1R", "2階", "北", "2026/04/12 20:55", 30),
+            ("new-2", "b-sale", "mansion_review_mansion", "u3", "e3", 3500000, 3500, 2200, 390000, 19.35, "1R", "3階", "南西", "2026/04/12 20:55", 30),
+            ("new-3", "b-sale", "mansion_review_mansion", "u4", "e4", 3000000, 3300, 2100, 380000, 19.35, "1R", "4階", "東", "2026/04/12 20:55", 30),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    rebuild(str(db))
+
+    conn = connect(db)
+    summary = conn.execute(
+        "SELECT sale_listing_count, sale_price_yen_min, sale_price_yen_max, sale_area_sqm_min, sale_area_sqm_max FROM building_summaries WHERE building_key='b-sale'"
+    ).fetchone()
+    sale_summary = conn.execute(
+        "SELECT sale_listing_count, price_yen_min, price_yen_max, area_sqm_min, area_sqm_max, floor_summary, direction_summary FROM building_sale_summaries WHERE building_key='b-sale'"
+    ).fetchone()
+    conn.close()
+
+    assert summary["sale_listing_count"] == 3
+    assert summary["sale_price_yen_min"] == 2200000
+    assert summary["sale_price_yen_max"] == 3500000
+    assert summary["sale_area_sqm_min"] == 19.35
+    assert summary["sale_area_sqm_max"] == 19.35
+    assert sale_summary["sale_listing_count"] == 3
+    assert sale_summary["price_yen_min"] == 2200000
+    assert sale_summary["price_yen_max"] == 3500000
+    assert sale_summary["area_sqm_min"] == 19.35
+    assert sale_summary["area_sqm_max"] == 19.35
+    assert set((sale_summary["floor_summary"] or "").split(", ")) == {"2階", "3階", "4階"}
+    assert set((sale_summary["direction_summary"] or "").split(", ")) == {"北", "南西", "東"}
+    assert "ワンルーム" not in (sale_summary["direction_summary"] or "")


### PR DESCRIPTION
### Motivation
- Ensure `building_sale_summaries` and `building_summaries` reflect the latest valid sale rows from `sale_listings` and avoid contamination by old or malformed rows. 
- Prevent layout-like tokens (e.g. `ワンルーム`) from being treated as directions and make all sale-derived fields come from the same filtered set.

### Description
- Added `_is_effective_sale_item` and `_filter_latest_valid_sale_items` to normalize sale rows and select an effective, latest snapshot-style subset for aggregation. 
- Cleaned `direction_text` during normalization to strip layout-like patterns using `_SALE_LAYOUT_RE` so layout tokens do not appear in `direction_summary`. 
- Derived `price_yen_min/max/avg`, `area_sqm_min/max`, `layout_types_json`, `floor_summary`, `direction_summary`, `sale_listing_count`, and `sale_latest` consistently from the filtered sale item set and used `_distinct_in_seen_order` for floor ordering and natural sort for directions. 
- Kept changes limited to `src/tatemono_map/normalize/building_summaries.py` and added a focused regression test `test_sale_summary_uses_latest_valid_snapshot_rows_only` in `tests/test_building_summaries.py` to cover mixed old/new sale rows and direction cleanup.

### Testing
- Ran `pytest -q tests/test_building_summaries.py` and all tests succeeded (`16 passed`).
- Ran the focused set `pytest -q tests/test_building_summaries.py -k 'sale_summary_uses_sale_listings_payload or sale_summary_hides_single_price_fallback_when_count_is_plural_without_sale_listings or sale_summary_uses_latest_valid_snapshot_rows_only'` and the targeted tests passed. 
- Commit hash for the change is `f91d409`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc717dcfb0832694368e4490989ec8)