### PR TITLE
Fix sqlite3.Row access in building sale trace logging

### DIFF
--- a/src/tatemono_map/normalize/building_summaries.py
+++ b/src/tatemono_map/normalize/building_summaries.py
@@ -628,7 +628,9 @@ def rebuild(db_path: str) -> int:
                     "building_key": building_key,
                     "sale_rows_raw_count": len(sale_items),
                     "sale_rows_updated_at_list": [
-                        normalize_text(row.get("updated_at")) for row in sale_items if normalize_text(row.get("updated_at"))
+                        normalize_text(dict(row).get("updated_at"))
+                        for row in sale_items
+                        if normalize_text(dict(row).get("updated_at"))
                     ],
                     "normalized_sale_items_count": len(normalized_sale_rows_all),
                     "filtered_sale_items_count": len(filtered_sale_items),


### PR DESCRIPTION
### Motivation
- Trace-only code in `src/tatemono_map/normalize/building_summaries.py` attempted to call `.get()` on `sqlite3.Row` objects while building `sale_rows_updated_at_list`, causing `AttributeError: 'sqlite3.Row' object has no attribute 'get'` during trace runs.
- The change is limited to making the trace code robust against `sqlite3.Row` objects without touching the sale-summary aggregation or upsert/business logic.

### Description
- Replace usages of `row.get("updated_at")` in the trace list comprehension with `dict(row).get("updated_at")` so `sqlite3.Row` is converted to `dict` before accessing keys, applied at `src/tatemono_map/normalize/building_summaries.py` around lines 630--634.
- No changes were made to aggregation, upsert conditions, or any production logic that computes sale summaries; only trace output collection was modified.
- Trace-related identifiers (`TATEMONO_TRACE_OUT`, `building_summaries_sale_trace`, `post_upsert`, `upsert_payload`) remain present.

### Testing
- Ran `TATEMONO_TRACE_OUT=/workspace/tatemono-map/tmp/trace.json PYTHONPATH=src python -m tatemono_map.normalize.building_summaries --db-path data/tatemono_map.sqlite3` which executed successfully and printed `rebuilt building_summaries: 0` (local DB in this environment has no listings so no trace targets were hit). — success.
- Ran `TATEMONO_TRACE_OUT=/workspace/tatemono-map/tmp/trace.json python -m tatemono_map.normalize.building_summaries --db-path data/tatemono_map.sqlite3` which failed with `ModuleNotFoundError: No module named 'tatemono_map'` as expected without `PYTHONPATH=src` set — failure as environment-usage note.
- Searched the file for trace keywords with `rg -n "TATEMONO_TRACE_OUT|building_summaries_sale_trace|post_upsert|upsert_payload"` to confirm trace code remains — success.
- Note: no trace JSON file was produced in this environment because the provided `data/tatemono_map.sqlite3` contains zero buildings/listings so none of the trace target names were encountered.

Commit hash: `449db0f`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9433401c83268a35c802e1f6c16a)