### PR TITLE
Fix sale_rows filter in rebuild to include latest finished ingest per source

### DIFF
--- a/src/tatemono_map/normalize/building_summaries.py
+++ b/src/tatemono_map/normalize/building_summaries.py
@@ -315,6 +315,14 @@ def rebuild(db_path: str) -> int:
         FROM sale_listings
         WHERE (
             ingest_run_id IN (SELECT ingest_run_id FROM current_ingest_snapshots)
+            OR ingest_run_id = (
+                SELECT ir.id
+                FROM ingest_runs ir
+                WHERE ir.source = sale_listings.source
+                  AND ir.status = 'finished'
+                ORDER BY ir.id DESC
+                LIMIT 1
+            )
             OR (
                 ingest_run_id IS NULL
                 AND NOT EXISTS (SELECT 1 FROM current_ingest_snapshots)


### PR DESCRIPTION
### Motivation
- Traces showed `rebuild()` saw only old snapshot rows (2026-04-10) so newer valid sale rows (2026-04-12) were excluded and downstream fields became null or incorrect. 
- The intent is to minimally widen the `sale_rows` selection so `rebuild()` picks up the latest finished ingest per `sale_listings.source` when current snapshot switching lags. 
- `_filter_latest_valid_sale_items` and the UPSERT logic must remain unchanged; only the pre-upsert selection is targeted. 

### Description
- Edited `src/tatemono_map/normalize/building_summaries.py` to add a fallback condition in the `sale_listings` `WHERE` clause so rows with `ingest_run_id` equal to the latest `finished` `ingest_runs.id` for the same `sale_listings.source` are included. 
- The change is a minimal SQL addition inside `rebuild()` that preserves the existing `current_ingest_snapshots` filter and the `ingest_run_id IS NULL` behavior. 
- No changes made to `_filter_latest_valid_sale_items` or any UPSERT/summary aggregation logic. 
- Commit: `8bbbc07`.

### Testing
- Ran `PYTHONPATH=src python -m tatemono_map.normalize.building_summaries --db-path /tmp/public.copy.sqlite3` which completed successfully and rebuilt summaries. 
- Ran `python -m compileall src/tatemono_map/normalize/building_summaries.py` which succeeded. 
- An initial run without `PYTHONPATH` failed with `ModuleNotFoundError` as expected and was not used further. 
- Note: the repository copy DB available here did not contain the four traced sale rows, so per-building before/after verification for those four targets could not be reproduced in this environment, but the selection change is limited to the `sale_rows` SQL condition described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc98372e3c83269ebc8640b3f8893b)