### PR TITLE
Fix sale_rows fallback to latest finished sale ingest runs

### DIFF
--- a/src/tatemono_map/normalize/building_summaries.py
+++ b/src/tatemono_map/normalize/building_summaries.py
@@ -311,18 +311,20 @@ def rebuild(db_path: str) -> int:
     ).fetchall()
     sale_rows = conn.execute(
         """
+        WITH latest_finished_sale_runs AS (
+            SELECT sl.source, MAX(sl.ingest_run_id) AS ingest_run_id
+            FROM sale_listings sl
+            JOIN ingest_runs ir
+              ON ir.id = sl.ingest_run_id
+             AND ir.status = 'finished'
+            WHERE sl.ingest_run_id IS NOT NULL
+            GROUP BY sl.source
+        )
         SELECT building_key, price_yen, management_fee_yen, repair_fund_yen, tsubo_unit_price_yen AS sqm_unit_price_yen, area_sqm, layout, floor_text, direction_text, updated_at, source
         FROM sale_listings
         WHERE (
             ingest_run_id IN (SELECT ingest_run_id FROM current_ingest_snapshots)
-            OR ingest_run_id = (
-                SELECT ir.id
-                FROM ingest_runs ir
-                WHERE ir.source = sale_listings.source
-                  AND ir.status = 'finished'
-                ORDER BY ir.id DESC
-                LIMIT 1
-            )
+            OR ingest_run_id IN (SELECT ingest_run_id FROM latest_finished_sale_runs)
             OR (
                 ingest_run_id IS NULL
                 AND NOT EXISTS (SELECT 1 FROM current_ingest_snapshots)


### PR DESCRIPTION
### Motivation
- `rebuild()` が `sale_rows` を抽出する際、`ingest_runs` の最新 finished を直接参照する旧ロジックが `sale_listings` 側の実在する ingest_run とズレてしまい、古い（stale）行だけが拾われるケースが発生していたため一般的に直す必要があった。 
- 変更は全 building_key に効く一般ロジックで、個別ハードコードや建物名分岐は一切行っていない。

### Description
- `rebuild()` 内の `sale_rows` 抽出 SQL に CTE `latest_finished_sale_runs` を追加して、`sale_listings` に存在し、かつ `ingest_runs.status = 'finished'` なソースごとの最新 `ingest_run_id` を取得するようにした。 
- 旧相関サブクエリによる `ingest_runs` 側の最新 finished 指名を、`ingest_run_id IN (SELECT ingest_run_id FROM latest_finished_sale_runs)` に置換して、必ず `sale_listings` に実在する run を fallback の対象とするようにした。 
- 触ったのは `sale_rows` を得る SQL/CTE のみで、`_filter_latest_valid_sale_items`／UPSERT 本体／UI やレンダリング周りは変更していない。 

### Testing
- `pytest` を実行して `tests/test_building_summaries.py` の全テストが通過したことを確認した（`16 passed`）。
- コピー DB 上で `PYTHONPATH=src TATEMONO_TRACE_OUT=/tmp/building_summaries_sale_trace.json python -m tatemono_map.normalize.building_summaries --db-path /tmp/tatemono_copy.sqlite3` を実行して `rebuild()` を走らせた（trace ファイル出力あり）。
- 代表4棟の before/after（`building_sale_summaries` 上、public DB -> 修正後コピー DB）を確認した結果は次の通りで、公開 DB の `sale_listings`/`ingest_runs` が空のため限定的な差分となった。  
  - エクレール東新町: before updated_at=`2026/04/10 16:18`, sale_listing_count=1, price present; after updated_at=`None`, sale_listing_count=1, price unchanged.  
  - エメラルドハイツ大里3: before updated_at=`2026/04/10 16:18`, sale_listing_count=3, price null; after updated_at=`None`, sale_listing_count=3.  
  - パサージュ門司: before updated_at=`2026/04/10 16:18`, direction_summary=`ワンルーム`; after direction_summary=`None`.  
  - 門司港レトロハイマート: before updated_at=`2026/04/10 16:18`, sale_listing_count=4; after updated_at=`None`, sale_listing_count=4.  
- 全体集計（`building_sale_summaries`、条件: `COALESCE(sale_listing_count,0)>0`）の before/after は次のとおりで、公開 DB の実データ欠如のため差分は小さい。  
  - `price_yen_min/max` が NULL の件数: `322 -> 322`。  
  - `floor_summary` が NULL の件数: `712 -> 712`。  
  - `direction_summary` が NULL の件数: `711 -> 712`。  
  - `direction_summary` に layout語が混入している件数（簡易ヒューリスティック）: `1 -> 0`。  
- 実行したテストとコマンドは `pytest`（上記）および `PYTHONPATH=src ... python -m tatemono_map.normalize.building_summaries`（上記）であり、どちらも成功した。 

commit hash: `180d3fb`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9f32ca888326ba5380df271ee6cc)