### PR TITLE
Fix rebuild sale row extraction to avoid stale snapshot filtering

### DIFF
--- a/src/tatemono_map/normalize/building_summaries.py
+++ b/src/tatemono_map/normalize/building_summaries.py
@@ -311,25 +311,8 @@ def rebuild(db_path: str) -> int:
     ).fetchall()
     sale_rows = conn.execute(
         """
-        WITH latest_finished_sale_runs AS (
-            SELECT sl.source, MAX(sl.ingest_run_id) AS ingest_run_id
-            FROM sale_listings sl
-            JOIN ingest_runs ir
-              ON ir.id = sl.ingest_run_id
-             AND ir.status = 'finished'
-            WHERE sl.ingest_run_id IS NOT NULL
-            GROUP BY sl.source
-        )
         SELECT building_key, price_yen, management_fee_yen, repair_fund_yen, tsubo_unit_price_yen AS sqm_unit_price_yen, area_sqm, layout, floor_text, direction_text, updated_at, source
         FROM sale_listings
-        WHERE (
-            ingest_run_id IN (SELECT ingest_run_id FROM current_ingest_snapshots)
-            OR ingest_run_id IN (SELECT ingest_run_id FROM latest_finished_sale_runs)
-            OR (
-                ingest_run_id IS NULL
-                AND NOT EXISTS (SELECT 1 FROM current_ingest_snapshots)
-            )
-        )
         ORDER BY id DESC
         """
     ).fetchall()


### PR DESCRIPTION
### Motivation
- The prior `rebuild()` extracted sale rows with `current_ingest_snapshots` / `ingest_runs` filtering which could drop newer valid `sale_listings` before normalization, causing stale values to propagate to summaries.
- The goal was a minimal, general fix that preserves `_filter_latest_valid_sale_items()` and UPSERT behavior while avoiding any building-specific branching.
- Rental listing logic and UI/crawler/templates were intentionally left untouched.

### Description
- Changed `rebuild()` sale rows extraction SQL to `SELECT ... FROM sale_listings ORDER BY id DESC`, removing the prior `current_ingest_snapshots` / `latest_finished_sale_runs` / `ingest_run_id IS NULL` pre-filter so all `sale_listings` are considered.
- Kept the downstream `normalized_sale_items = _filter_latest_valid_sale_items(sale_items)` call and all `INSERT ... ON CONFLICT DO UPDATE` UPSERT logic unchanged.
- Left rental `listings` extraction and trace code intact; no building-key hardcoding was introduced.

### Testing
- Ran syntax check with `python -m py_compile src/tatemono_map/normalize/building_summaries.py` which succeeded.
- Executed `PYTHONPATH=src TATEMONO_TRACE_OUT=tmp/building_summaries_sale_trace.json python -m tatemono_map.normalize.building_summaries --db-path data/public/public.sqlite3` which completed (`rebuilt building_summaries: 6975`) and produced traces, but the test database had `sale_listings = 0` so the environment could not validate the expected before/after changes for the target buildings.
- Queried summary metrics before/after in the available `public.sqlite3`; metrics ran successfully but showed no effective change due to empty `sale_listings` in the test DB.

Commit: `4503e91`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca3b6f8e08326bd97e7364e7c6224)