### PR TITLE
Mansion Review 分譲の価格表示を exact/nonexact で統一（一覧・詳細）

### DIFF
--- a/src/tatemono_map/normalize/building_summaries.py
+++ b/src/tatemono_map/normalize/building_summaries.py
@@ -409,7 +409,11 @@ def rebuild(db_path: str) -> int:
         normalized_sale_items = _filter_latest_valid_sale_items(sale_items)
         normalized_sale_rows_all = [_normalize_sale_row_fields(dict(r)) for r in sale_items]
         filtered_sale_items = normalized_sale_items
+        sale_listing_count_total = len(normalized_sale_items)
         sale_prices = [int(r["price_yen"]) for r in normalized_sale_items if r["price_yen"] is not None]
+        sale_price_exact_count = len(sale_prices)
+        sale_price_nonexact_count = max(0, sale_listing_count_total - sale_price_exact_count)
+        sale_price_has_nonexact = sale_price_nonexact_count > 0
         sale_areas = [float(r["area_sqm"]) for r in normalized_sale_items if r["area_sqm"] is not None]
         sale_layouts = _distinct_natural([str(r.get("layout") or "") for r in normalized_sale_items])
         sale_mgmt_fees = [int(r["management_fee_yen"]) for r in normalized_sale_items if r["management_fee_yen"] is not None]
@@ -419,9 +423,9 @@ def rebuild(db_path: str) -> int:
         sale_directions = _distinct_natural([str(r.get("direction_text") or "") for r in normalized_sale_items])
         sale_latest = max((r["updated_at"] for r in normalized_sale_items if r["updated_at"]), default=None)
 
-        sale_price_min = min(sale_prices) if sale_prices else (building["sale_price_yen_min"] if building else None)
-        sale_price_max = max(sale_prices) if sale_prices else (building["sale_price_yen_max"] if building else None)
-        sale_price_avg = (sum(sale_prices) // len(sale_prices)) if sale_prices else (building["sale_price_yen_avg"] if building else None)
+        sale_price_min = min(sale_prices) if sale_prices else (building["sale_price_yen_min"] if building and sale_listing_count_total <= 0 else None)
+        sale_price_max = max(sale_prices) if sale_prices else (building["sale_price_yen_max"] if building and sale_listing_count_total <= 0 else None)
+        sale_price_avg = (sum(sale_prices) // len(sale_prices)) if sale_prices else (building["sale_price_yen_avg"] if building and sale_listing_count_total <= 0 else None)
         sale_area_min = min(sale_areas) if sale_areas else (building["sale_area_sqm_min"] if building else None)
         sale_area_max = max(sale_areas) if sale_areas else (building["sale_area_sqm_max"] if building else None)
         sale_layout_types_json = (
@@ -429,11 +433,7 @@ def rebuild(db_path: str) -> int:
             if sale_layouts
             else (building["sale_layout_types_json"] if building else None)
         )
-        sale_listing_count = (
-            len(normalized_sale_items)
-            if normalized_sale_items
-            else (building["sale_listing_count"] if building else None)
-        )
+        sale_listing_count = sale_listing_count_total if normalized_sale_items else (building["sale_listing_count"] if building else None)
         if (
             not sale_prices
             and (sale_listing_count or 0) > 1
@@ -539,6 +539,10 @@ def rebuild(db_path: str) -> int:
             )
         sale_upsert_payload = {
             "sale_listing_count": sale_listing_count or 0,
+            "sale_listing_count_total": sale_listing_count_total,
+            "sale_price_exact_count": sale_price_exact_count,
+            "sale_price_nonexact_count": sale_price_nonexact_count,
+            "sale_price_has_nonexact": sale_price_has_nonexact,
             "price_yen_min": sale_price_min,
             "price_yen_max": sale_price_max,
             "price_yen_avg": sale_price_avg,

--- a/src/tatemono_map/render/build.py
+++ b/src/tatemono_map/render/build.py
@@ -199,6 +199,32 @@ def _format_layout_label(layout_types: list[str]) -> str | None:
     return f"{labels[0]}〜{labels[-1]}"
 
 
+def _resolve_sale_price_label(
+    *,
+    sale_listing_count_total: int,
+    sale_price_exact_count: int,
+    sale_price_yen_min: int | None,
+    sale_price_yen_max: int | None,
+) -> str:
+    if sale_listing_count_total <= 0:
+        return "—"
+    if sale_price_exact_count <= 0:
+        return "販売中"
+    if sale_listing_count_total == sale_price_exact_count:
+        return _format_range(
+            (sale_price_yen_min / 10000) if sale_price_yen_min is not None else None,
+            (sale_price_yen_max / 10000) if sale_price_yen_max is not None else None,
+            suffix="万円",
+        ) or "販売中"
+    if sale_price_exact_count == 1:
+        return "販売中"
+    return _format_range(
+        (sale_price_yen_min / 10000) if sale_price_yen_min is not None else None,
+        (sale_price_yen_max / 10000) if sale_price_yen_max is not None else None,
+        suffix="万円",
+    ) or "販売中"
+
+
 def _format_text_label(values: list[object]) -> str | None:
     labels: list[str] = []
     for value in values:
@@ -1053,6 +1079,9 @@ def _load_buildings(db_path: str) -> tuple[list[dict], int, int, int, int]:
         direction_list = _distinct_natural_text(current.get("direction_values") or [])
         sale_current_map[canonical_key] = {
             "listing_count": int(current.get("listing_count") or 0),
+            "price_exact_count": len(price_values),
+            "price_nonexact_count": max(0, int(current.get("listing_count") or 0) - len(price_values)),
+            "price_has_nonexact": max(0, int(current.get("listing_count") or 0) - len(price_values)) > 0,
             "price_min": min(price_values) if price_values else None,
             "price_max": max(price_values) if price_values else None,
             "area_min": min(area_values) if area_values else None,
@@ -1296,15 +1325,37 @@ def _build_dist_version(
         b["display_address"] = _build_display_address(b.get("address"))
         b["render_address"] = b.get("display_address") if selected_mode == "short" else b.get("address_full")
         sale_current = b.get("sale_current") or {}
-        sale_count = int(sale_current.get("listing_count") or 0)
+        sale_summary = b.get("sale_summary") or {}
+        sale_count = int(sale_current.get("listing_count") or sale_summary.get("sale_listing_count") or 0)
+        sale_exact_count = int(sale_current.get("price_exact_count") or 0)
+        if sale_exact_count <= 0 and sale_count > 0 and sale_summary.get("price_yen_min") is not None:
+            sale_exact_count = sale_count
+        sale_nonexact_count = int(sale_current.get("price_nonexact_count") or max(0, sale_count - sale_exact_count))
         sale_price_min = sale_current.get("price_min")
+        if sale_price_min is None:
+            sale_price_min = sale_summary.get("price_yen_min")
         sale_price_max = sale_current.get("price_max")
+        if sale_price_max is None:
+            sale_price_max = sale_summary.get("price_yen_max")
         sale_area_min = sale_current.get("area_min")
+        if sale_area_min is None:
+            sale_area_min = sale_summary.get("area_sqm_min")
         sale_area_max = sale_current.get("area_max")
+        if sale_area_max is None:
+            sale_area_max = sale_summary.get("area_sqm_max")
         b["sale_listing_count"] = sale_count
+        b["sale_price_exact_count"] = sale_exact_count
+        b["sale_price_nonexact_count"] = sale_nonexact_count
+        b["sale_price_has_nonexact"] = sale_nonexact_count > 0
         b["sale_price_yen_min"] = sale_price_min
         b["sale_price_yen_max"] = sale_price_max
         b["sale_price_yen_avg"] = int((sale_price_min + sale_price_max) / 2) if sale_price_min is not None and sale_price_max is not None else None
+        b["sale_price_label"] = _resolve_sale_price_label(
+            sale_listing_count_total=sale_count,
+            sale_price_exact_count=sale_exact_count,
+            sale_price_yen_min=sale_price_min,
+            sale_price_yen_max=sale_price_max,
+        )
         b["sale_area_sqm_min"] = sale_area_min
         b["sale_area_sqm_max"] = sale_area_max
         has_sale = bool(b.get("has_sale")) or bool((b.get("sale_listing_count") or 0) > 0)
@@ -1439,7 +1490,14 @@ def _build_dist_version(
         b["display_structure"] = _normalize_structure_label(b.get("building_structure") or b.get("structure"))
         sale_current = b.get("sale_current") or {}
         sale_count = int(sale_current.get("listing_count") or sale_summary.get("sale_listing_count") or 0)
+        sale_exact_count = int(sale_current.get("price_exact_count") or 0)
+        if sale_exact_count <= 0 and sale_count > 0 and sale_summary.get("price_yen_min") is not None:
+            sale_exact_count = sale_count
+        sale_nonexact_count = int(sale_current.get("price_nonexact_count") or max(0, sale_count - sale_exact_count))
         b["sale_listing_count"] = sale_count
+        b["sale_price_exact_count"] = sale_exact_count
+        b["sale_price_nonexact_count"] = sale_nonexact_count
+        b["sale_price_has_nonexact"] = sale_nonexact_count > 0
         b["sale_status_label"] = f"{sale_count}件" if sale_count > 0 else "現在、販売中の住戸はありません。"
         sale_price_min = sale_current.get("price_min")
         if sale_price_min is None:
@@ -1450,10 +1508,11 @@ def _build_dist_version(
         b["sale_price_yen_min"] = sale_price_min
         b["sale_price_yen_max"] = sale_price_max
         b["sale_price_yen_avg"] = int((sale_price_min + sale_price_max) / 2) if sale_price_min is not None and sale_price_max is not None else None
-        b["sale_price_label"] = _format_range(
-            (sale_price_min / 10000) if sale_price_min is not None else None,
-            (sale_price_max / 10000) if sale_price_max is not None else None,
-            suffix="万円",
+        b["sale_price_label"] = _resolve_sale_price_label(
+            sale_listing_count_total=sale_count,
+            sale_price_exact_count=sale_exact_count,
+            sale_price_yen_min=sale_price_min,
+            sale_price_yen_max=sale_price_max,
         )
         sale_area_min = sale_current.get("area_min")
         if sale_area_min is None:

--- a/templates_v2/index.html.j2
+++ b/templates_v2/index.html.j2
@@ -164,9 +164,7 @@
             <li class="kpi"><span>販売情報</span>{% if b.sale_listing_count is not none and b.sale_listing_count > 0 %}{{ b.sale_listing_count }}件{% else %}なし{% endif %}</li>
           {% elif b.listing_mode == "sale" %}
             <li class="kpi"><span>販売情報</span>{% if b.sale_listing_count is not none and b.sale_listing_count > 0 %}{{ b.sale_listing_count }}件{% else %}なし{% endif %}</li>
-            {% set sale_price_min = b.sale_price_yen_min if b.sale_price_yen_min is not none and b.sale_price_yen_min > 0 else none %}
-            {% set sale_price_max = b.sale_price_yen_max if b.sale_price_yen_max is not none and b.sale_price_yen_max > 0 else none %}
-            <li class="kpi"><span>販売価格</span>{% if sale_price_min and sale_price_max %}{% if sale_price_min == sale_price_max %}{{ ((sale_price_min / 10000)|int) }}万円{% else %}{{ ((sale_price_min / 10000)|int) }}万円〜{{ ((sale_price_max / 10000)|int) }}万円{% endif %}{% elif sale_price_min %}{{ ((sale_price_min / 10000)|int) }}万円{% elif sale_price_max %}{{ ((sale_price_max / 10000)|int) }}万円{% else %}—{% endif %}</li>
+            <li class="kpi"><span>販売価格</span>{{ b.sale_price_label or "—" }}</li>
           {% else %}
             <li class="kpi"><span>空室</span>{{ b.vacancy_count if b.vacancy_count is not none else "—" }}件</li>
             {% set rent_min = b.rent_yen_min if b.rent_yen_min is not none and b.rent_yen_min > 0 else none %}

--- a/tests/test_building_summaries.py
+++ b/tests/test_building_summaries.py
@@ -275,6 +275,45 @@ def test_summary_fallbacks_to_buildings_for_zero_vacancy(tmp_path):
     assert row["building_availability_label"] is None
 
 
+def test_sale_summary_uses_total_count_and_exact_only_price_range(tmp_path):
+    db = tmp_path / "sale_summary.sqlite3"
+    conn = connect(db)
+    conn.execute(
+        """
+        INSERT INTO buildings(building_id, canonical_name, canonical_address, property_kind)
+        VALUES ('b-sale', '分譲集計テスト', '福岡県北九州市小倉北区', 'bunjo')
+        """
+    )
+    conn.executemany(
+        """
+        INSERT INTO sale_listings(
+            sale_listing_key, building_key, source, source_url, evidence_id,
+            price_yen, area_sqm, layout, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            ("s1", "b-sale", "mansion_review_mansion", "u1", "e1", 42000000, 70.0, "3LDK", "2026-04-01"),
+            ("s2", "b-sale", "mansion_review_mansion", "u2", "e2", None, 71.0, "3LDK", "2026-04-01"),
+            ("s3", "b-sale", "mansion_review_mansion", "u3", "e3", 45000000, 72.0, "3LDK", "2026-04-01"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    rebuild(str(db))
+    conn = connect(db)
+    row = conn.execute("SELECT sale_listing_count, sale_price_yen_min, sale_price_yen_max FROM building_summaries WHERE building_key='b-sale'").fetchone()
+    sale_row = conn.execute("SELECT sale_listing_count, price_yen_min, price_yen_max FROM building_sale_summaries WHERE building_key='b-sale'").fetchone()
+    conn.close()
+
+    assert row["sale_listing_count"] == 3
+    assert row["sale_price_yen_min"] == 42000000
+    assert row["sale_price_yen_max"] == 45000000
+    assert sale_row["sale_listing_count"] == 3
+    assert sale_row["price_yen_min"] == 42000000
+    assert sale_row["price_yen_max"] == 45000000
+
+
 def test_summary_uses_current_snapshot_only_and_keeps_zero_vacancy_buildings(tmp_path):
     db = tmp_path / "test9.sqlite3"
     conn = connect(db)

--- a/tests/test_render_dist.py
+++ b/tests/test_render_dist.py
@@ -85,7 +85,7 @@ def test_render_dist_creates_nojekyll_file(tmp_path):
     conn.close()
 
     rebuild(str(db))
-    build_dist(str(db), str(dist))
+    build_dist(str(db), str(dist), template_root="templates_v2")
 
     assert (dist / ".nojekyll").exists()
 
@@ -200,6 +200,42 @@ def test_render_dist_sale_summary_alias_fallback_and_duplicate_suppression(tmp_p
     assert "54.9万円/㎡" in detail
     assert "7階" in detail
     assert "南" in detail
+
+
+def test_render_dist_sale_price_label_is_on_sale_when_only_one_exact_in_total(tmp_path):
+    db = tmp_path / "test_sale_partial.sqlite3"
+    dist = tmp_path / "dist"
+    conn = connect(db)
+    conn.execute(
+        """
+        INSERT INTO buildings(building_id, canonical_name, canonical_address, property_kind)
+        VALUES ('b-sale-partial', '分譲モザイクテスト', '福岡県北九州市小倉北区魚町1-1-1', 'bunjo')
+        """
+    )
+    conn.executemany(
+        """
+        INSERT INTO sale_listings(
+            sale_listing_key, building_key, source, source_url, evidence_id,
+            price_yen, area_sqm, layout, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            ("sale-p1", "b-sale-partial", "mansion_review_mansion", "u1", "e1", 39800000, 72.5, "3LDK", "2026-04-01"),
+            ("sale-p2", "b-sale-partial", "mansion_review_mansion", "u2", "e2", None, 73.0, "3LDK", "2026-04-01"),
+            ("sale-p3", "b-sale-partial", "mansion_review_mansion", "u3", "e3", None, 74.0, "3LDK", "2026-04-01"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    rebuild(str(db))
+    build_dist(str(db), str(dist), template_root="templates_v2")
+
+    index = (dist / "index.html").read_text(encoding="utf-8")
+    assert "販売価格</span>販売中" in index
+    detail = (dist / "b" / "分譲モザイクテスト-b-sale-partial.html").read_text(encoding="utf-8")
+    assert "<dt>販売状況</dt><dd>3件</dd>" in detail
+    assert "<dt>価格</dt><dd>販売中</dd>" in detail
 
 
 def test_render_dist_fails_when_forbidden_text_exists(tmp_path):


### PR DESCRIPTION
### Motivation
- 分譲の販売件数と価格表示の整合を取り、モザイク／帯価格を exact 値に混ぜないことで公開ページの表示意味を明確化するため。

### Description
- summary 集約で `sale_listing_count_total` / `sale_price_exact_count` / `sale_price_nonexact_count` / `sale_price_has_nonexact` を算出し、`price_yen` がある行のみで `sale_price_yen_min/max/avg` を算出するよう最小差分で追加した（ファイル: `src/tatemono_map/normalize/building_summaries.py`）。
- レンダリング側に `_resolve_sale_price_label(...)` を追加して一覧と詳細で共通の表示ルールを適用し、ルールは total/exact の組合せに基づいて `販売中`／単値／min〜max を決定する（ファイル: `src/tatemono_map/render/build.py`）。
- `sale_current` 集約に `price_exact_count/price_nonexact_count/price_has_nonexact` を保持するようにし、既存の summary にしか価格情報がないケースでは互換的に扱う最小補完を加えた（ファイル: `src/tatemono_map/render/build.py`）。
- v2 一覧テンプレートで個別 min/max 判定から `b.sale_price_label` 参照に切替え表示を統一した（ファイル: `templates_v2/index.html.j2`）。
- ユニットテストを追加・更新して、新ルールが意図どおり動作することを検証した（ファイル: `tests/test_building_summaries.py`, `tests/test_render_dist.py`）。
- 変更は最小差分に留め、建物名ハードコード・レイアウト変更・ドキュメント大改修は行っていません。

### Testing
- 実行した自動テスト: `pytest -q tests/test_building_summaries.py::test_sale_summary_uses_total_count_and_exact_only_price_range` (passed).
- 実行した自動テスト: `pytest -q tests/test_render_dist.py::test_render_dist_sale_summary_alias_fallback_and_duplicate_suppression` (passed).
- 実行した自動テスト: `pytest -q tests/test_render_dist.py::test_render_dist_sale_price_label_is_on_sale_when_only_one_exact_in_total` (passed).

commit hash: `312ba32`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb7dd0a5c8326936f1e05c4a7ae24)