### PR TITLE
Mansion Review sale summaries: prefer latest snapshot rows only

### DIFF
--- a/src/tatemono_map/normalize/building_summaries.py
+++ b/src/tatemono_map/normalize/building_summaries.py
@@ -170,23 +170,40 @@ def _is_effective_sale_item(row: dict) -> bool:
 
 def _filter_latest_valid_sale_items(sale_items: list[dict]) -> list[dict]:
     normalized = [_normalize_sale_row_fields(dict(r)) for r in sale_items]
-    effective = [row for row in normalized if _is_effective_sale_item(row)]
-    if not effective:
+    if not normalized:
         return []
 
-    dated = [row for row in effective if normalize_text(row.get("updated_at"))]
-    if not dated:
-        return effective
+    mansion_review_rows = [row for row in normalized if str(row.get("source") or "") == "mansion_review_mansion"]
+    other_source_rows = [row for row in normalized if str(row.get("source") or "") != "mansion_review_mansion"]
+    if not mansion_review_rows:
+        return normalized
 
-    normalized_timestamps = [normalize_text(row.get("updated_at")) or "" for row in dated]
-    distinct_timestamps = sorted(set(normalized_timestamps))
-    has_time_component = all(" " in ts for ts in distinct_timestamps if ts)
-    if not (has_time_component and len(distinct_timestamps) > 1):
-        return effective
+    rows_with_run_id = [row for row in mansion_review_rows if row.get("ingest_run_id") is not None]
+    if rows_with_run_id:
+        latest_run_id = max(int(row["ingest_run_id"]) for row in rows_with_run_id)
+        latest_run_rows = [row for row in mansion_review_rows if int(row["ingest_run_id"] or -1) == latest_run_id]
+        dated_in_latest_run = [row for row in latest_run_rows if normalize_text(row.get("updated_at"))]
+        if dated_in_latest_run:
+            distinct_timestamps = sorted({normalize_text(row.get("updated_at")) or "" for row in dated_in_latest_run})
+            has_time_component = all(" " in ts for ts in distinct_timestamps if ts)
+            if has_time_component and len(distinct_timestamps) > 1:
+                latest_ts = distinct_timestamps[-1]
+                latest_mansion_review_rows = [
+                    row for row in latest_run_rows if (normalize_text(row.get("updated_at")) or "") == latest_ts
+                ]
+            else:
+                latest_mansion_review_rows = latest_run_rows
+        else:
+            latest_mansion_review_rows = latest_run_rows
+    else:
+        dated = [row for row in mansion_review_rows if normalize_text(row.get("updated_at"))]
+        if dated:
+            latest_ts = max(normalize_text(row.get("updated_at")) or "" for row in dated)
+            latest_mansion_review_rows = [row for row in mansion_review_rows if (normalize_text(row.get("updated_at")) or "") == latest_ts]
+        else:
+            latest_mansion_review_rows = mansion_review_rows
 
-    latest_ts = distinct_timestamps[-1]
-    latest_rows = [row for row in dated if (normalize_text(row.get("updated_at")) or "") == latest_ts]
-    return latest_rows or effective
+    return latest_mansion_review_rows + other_source_rows
 
 
 def _nearest_availability_date(items: list) -> str | None:
@@ -311,7 +328,7 @@ def rebuild(db_path: str) -> int:
     ).fetchall()
     sale_rows = conn.execute(
         """
-        SELECT building_key, price_yen, management_fee_yen, repair_fund_yen, tsubo_unit_price_yen AS sqm_unit_price_yen, area_sqm, layout, floor_text, direction_text, updated_at, source
+        SELECT building_key, price_yen, management_fee_yen, repair_fund_yen, tsubo_unit_price_yen AS sqm_unit_price_yen, area_sqm, layout, floor_text, direction_text, updated_at, source, ingest_run_id
         FROM sale_listings
         ORDER BY id DESC
         """
@@ -426,12 +443,12 @@ def rebuild(db_path: str) -> int:
         sale_price_min = min(sale_prices) if sale_prices else (building["sale_price_yen_min"] if building and sale_listing_count_total <= 0 else None)
         sale_price_max = max(sale_prices) if sale_prices else (building["sale_price_yen_max"] if building and sale_listing_count_total <= 0 else None)
         sale_price_avg = (sum(sale_prices) // len(sale_prices)) if sale_prices else (building["sale_price_yen_avg"] if building and sale_listing_count_total <= 0 else None)
-        sale_area_min = min(sale_areas) if sale_areas else (building["sale_area_sqm_min"] if building else None)
-        sale_area_max = max(sale_areas) if sale_areas else (building["sale_area_sqm_max"] if building else None)
+        sale_area_min = min(sale_areas) if sale_areas else (building["sale_area_sqm_min"] if building and sale_listing_count_total <= 0 else None)
+        sale_area_max = max(sale_areas) if sale_areas else (building["sale_area_sqm_max"] if building and sale_listing_count_total <= 0 else None)
         sale_layout_types_json = (
             json.dumps(sale_layouts, ensure_ascii=False)
             if sale_layouts
-            else (building["sale_layout_types_json"] if building else None)
+            else (building["sale_layout_types_json"] if building and sale_listing_count_total <= 0 else None)
         )
         sale_listing_count = sale_listing_count_total if normalized_sale_items else (building["sale_listing_count"] if building else None)
         if (

--- a/tests/test_building_summaries.py
+++ b/tests/test_building_summaries.py
@@ -631,3 +631,109 @@ def test_sale_summary_uses_latest_valid_snapshot_rows_only(tmp_path):
     assert set((sale_summary["floor_summary"] or "").split(", ")) == {"2階", "3階", "4階"}
     assert set((sale_summary["direction_summary"] or "").split(", ")) == {"北", "南西", "東"}
     assert "ワンルーム" not in (sale_summary["direction_summary"] or "")
+
+
+def test_sale_summary_does_not_carry_over_old_exact_rows_when_latest_snapshot_is_nonexact_only(tmp_path):
+    db = tmp_path / "test_sale_latest_nonexact_only.sqlite3"
+    conn = connect(db)
+    conn.execute(
+        "INSERT INTO buildings(building_id, canonical_name, canonical_address, property_kind) VALUES ('b-sale','分譲マンション','福岡県北九州市小倉北区X','bunjo')"
+    )
+    conn.executemany(
+        """
+        INSERT INTO sale_listings(
+            sale_listing_key, building_key, source, source_url, evidence_id,
+            price_yen, area_sqm, layout, floor_text, direction_text, updated_at, ingest_run_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            ("old-1", "b-sale", "mansion_review_mansion", "u1", "e1", 36980000, 63.67, "2LDK", "5階", "南", "2026-03-01", 30),
+            ("latest-1", "b-sale", "mansion_review_mansion", "u2", "e2", None, None, None, None, None, "2026-04-01", 31),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    rebuild(str(db))
+
+    conn = connect(db)
+    summary = conn.execute(
+        """
+        SELECT sale_listing_count, sale_price_yen_min, sale_price_yen_max, sale_area_sqm_min, sale_area_sqm_max, sale_layout_types_json
+        FROM building_summaries
+        WHERE building_key='b-sale'
+        """
+    ).fetchone()
+    sale_summary = conn.execute(
+        """
+        SELECT sale_listing_count, price_yen_min, price_yen_max, area_sqm_min, area_sqm_max, floor_summary, direction_summary
+        FROM building_sale_summaries
+        WHERE building_key='b-sale'
+        """
+    ).fetchone()
+    conn.close()
+
+    assert summary["sale_listing_count"] == 1
+    assert summary["sale_price_yen_min"] is None
+    assert summary["sale_price_yen_max"] is None
+    assert summary["sale_area_sqm_min"] is None
+    assert summary["sale_area_sqm_max"] is None
+    assert summary["sale_layout_types_json"] is None
+    assert sale_summary["sale_listing_count"] == 1
+    assert sale_summary["price_yen_min"] is None
+    assert sale_summary["price_yen_max"] is None
+    assert sale_summary["area_sqm_min"] is None
+    assert sale_summary["area_sqm_max"] is None
+    assert sale_summary["floor_summary"] is None
+    assert sale_summary["direction_summary"] is None
+
+
+def test_sale_summary_aggregates_exact_rows_from_latest_snapshot_only(tmp_path):
+    db = tmp_path / "test_sale_latest_exact_only.sqlite3"
+    conn = connect(db)
+    conn.execute(
+        "INSERT INTO buildings(building_id, canonical_name, canonical_address, property_kind) VALUES ('b-sale','分譲マンション','福岡県北九州市門司区X','bunjo')"
+    )
+    conn.executemany(
+        """
+        INSERT INTO sale_listings(
+            sale_listing_key, building_key, source, source_url, evidence_id,
+            price_yen, area_sqm, layout, floor_text, direction_text, updated_at, ingest_run_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            ("old-1", "b-sale", "mansion_review_mansion", "u1", "e1", 29000000, 58.0, "2LDK", "3階", "西", "2026-03-01", 40),
+            ("new-1", "b-sale", "mansion_review_mansion", "u2", "e2", 32000000, 62.1, "3LDK", "6階", "南", "2026-04-01", 41),
+            ("new-2", "b-sale", "mansion_review_mansion", "u3", "e3", 34800000, 64.2, "3LDK", "8階", "東", "2026-04-01", 41),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    rebuild(str(db))
+
+    conn = connect(db)
+    summary = conn.execute(
+        "SELECT sale_listing_count, sale_price_yen_min, sale_price_yen_max, sale_area_sqm_min, sale_area_sqm_max FROM building_summaries WHERE building_key='b-sale'"
+    ).fetchone()
+    sale_summary = conn.execute(
+        """
+        SELECT sale_listing_count, price_yen_min, price_yen_max, area_sqm_min, area_sqm_max, floor_summary, direction_summary
+        FROM building_sale_summaries
+        WHERE building_key='b-sale'
+        """
+    ).fetchone()
+    conn.close()
+
+    assert summary["sale_listing_count"] == 2
+    assert summary["sale_price_yen_min"] == 32000000
+    assert summary["sale_price_yen_max"] == 34800000
+    assert summary["sale_area_sqm_min"] == 62.1
+    assert summary["sale_area_sqm_max"] == 64.2
+    assert sale_summary["sale_listing_count"] == 2
+    assert sale_summary["price_yen_min"] == 32000000
+    assert sale_summary["price_yen_max"] == 34800000
+    assert sale_summary["area_sqm_min"] == 62.1
+    assert sale_summary["area_sqm_max"] == 64.2
+    assert set((sale_summary["floor_summary"] or "").split(", ")) == {"6階", "8階"}
+    assert set((sale_summary["direction_summary"] or "").split(", ")) == {"南", "東"}


### PR DESCRIPTION
### Motivation
- Prevent summaries from carrying over exact sale data from older Mansion Review snapshots when the latest snapshot only exposes non-exact values. 
- Ensure all sale-related summary fields for 分譲 (Mansion Review) are derived consistently from a single per-building latest snapshot set. 
- Keep existing behavior for buildings that do have exact rows in the latest snapshot and avoid touching unrelated rendering, crawler or UI code. 

### Description
- Implemented per-building latest-snapshot selection for Mansion Review sale rows in `src/tatemono_map/normalize/building_summaries.py`, preferring `ingest_run_id` (highest) and then disambiguating within the run using `updated_at` only when timestamps include time and multiple values exist. 
- Updated sale-listings query to include `ingest_run_id` so snapshot grouping can be performed correctly. 
- Changed aggregation so all sale summary fields (count, exact/nonexact counts, price min/max/avg, area min/max, layouts, floor/direction summaries, and building_sale_summaries fields) are computed from the selected latest snapshot rows only, and building-table fallbacks (e.g., `sale_area_sqm_*`, `sale_layout_types_json`, price fallbacks) are used only when no latest snapshot rows exist for the building. 
- Added two focused regression tests to `tests/test_building_summaries.py` that validate (1) latest snapshot nonexact-only does not carry over old exact values and (2) latest snapshot exact rows are aggregated and older rows are excluded. 

### Testing
- Ran `pytest -q tests/test_building_summaries.py` and observed all tests pass: `19 passed`. 
- The new tests added are `test_sale_summary_does_not_carry_over_old_exact_rows_when_latest_snapshot_is_nonexact_only` and `test_sale_summary_aggregates_exact_rows_from_latest_snapshot_only`, and they passed in the suite. 
- Existing sale-summary related tests (including latest-snapshot and payload cases) were run and still pass after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc49846e88326bf6fa490297f56a9)