### PR TITLE
Mansion Review: treat non-exact sale rows as mosaic (blank fields)

### DIFF
--- a/scripts/mansion_review_crawl_to_csv.py
+++ b/scripts/mansion_review_crawl_to_csv.py
@@ -392,6 +392,12 @@ def _extract_chintai_row(cols: dict[str, str], cells: list[dict[str, str]], buil
 
 
 def _extract_mansion_row(cols: dict[str, str], cells: list[dict[str, str]], building_name: str) -> dict[str, str]:
+    def _has_mosaic_hint(value: str) -> bool:
+        text = normalize_space(value)
+        if not text:
+            return False
+        return any(token in text for token in ("万円台", "無料会員", "モザイク", "会員登録", "ログイン"))
+
     price = normalize_space(cols.get("価格") or cols.get("販売価格"))
     area = normalize_space(cols.get("専有面積") or cols.get("面積"))
     layout = normalize_space(cols.get("間取り"))
@@ -408,10 +414,22 @@ def _extract_mansion_row(cols: dict[str, str], cells: list[dict[str, str]], buil
         floor = ""
     if direction and not _is_direction_text(direction):
         direction = ""
-    if "万円台" in price or "無料会員" in price or "モザイク" in price:
+    if _has_mosaic_hint(price):
         price = ""
 
-    if not all((price, area, layout, floor, direction)):
+    mosaic_detected = any(
+        _has_mosaic_hint(value)
+        for value in (
+            price,
+            area,
+            layout,
+            floor,
+            direction,
+            *(cell["text"] for cell in cells),
+        )
+    )
+
+    if not mosaic_detected and not all((price, area, layout, floor, direction)):
         data_cells = [c for c in cells if not _is_deco_cell(c, building_name)]
         for cell in data_cells:
             text = cell["text"]
@@ -440,6 +458,17 @@ def _extract_mansion_row(cols: dict[str, str], cells: list[dict[str, str]], buil
             ):
                 price = text
                 continue
+
+    is_exact_row = not mosaic_detected and all((price, area, layout, floor, direction))
+    if not is_exact_row:
+        return {
+            "price_or_rent_text": "",
+            "tsubo_unit_price_text": "",
+            "area_text": "",
+            "layout_text": "",
+            "floor_text": "",
+            "direction_text": "",
+        }
 
     sqm_unit = _calc_sqm_unit_price_text(price, area)
     return {

--- a/tests/test_mansion_review_crawl_to_csv.py
+++ b/tests/test_mansion_review_crawl_to_csv.py
@@ -202,8 +202,9 @@ def test_parse_list_page_mansion_does_not_treat_layout_as_direction_on_shifted_c
         page_no=1,
     )
     row = rows[0]
-    assert row.layout_text == "1R"
-    assert row.floor_text == "5階"
+    assert row.price_or_rent_text == ""
+    assert row.layout_text == ""
+    assert row.floor_text == ""
     assert row.direction_text == ""
 
 
@@ -485,7 +486,7 @@ def test_parse_list_page_mansion_badge_cells_do_not_shift_columns() -> None:
     assert row.direction_text == "南東"
 
 
-def test_to_master_rows_mansion_keeps_row_when_price_is_empty() -> None:
+def test_to_master_rows_mansion_mosaic_row_stays_empty() -> None:
     row = ListRow(
         kind="mansion",
         city_id="1619",
@@ -513,6 +514,38 @@ def test_to_master_rows_mansion_keeps_row_when_price_is_empty() -> None:
     assert master["building_name"] == "モザイク価格マンション"
     assert master["rent_man"] == ""
     assert master["layout"] == "3LDK"
+
+
+def test_parse_list_page_mansion_partial_row_is_treated_as_mosaic() -> None:
+    html = """
+    <html><body>
+      <article class="property-detail-list-item">
+        <h3>部分欠損マンション</h3>
+        <table class="recommendTable"><tbody class="recommend_row">
+          <tr>
+            <td data-th="価格">4,680万円</td>
+            <td data-th="専有面積">72.5㎡</td>
+            <td data-th="間取り">3LDK</td>
+            <td data-th="所在階"></td>
+            <td data-th="向き">南</td>
+          </tr>
+        </tbody></table>
+      </article>
+    </body></html>
+    """
+    rows, _ = parse_list_page(
+        html,
+        page_url="https://www.mansion-review.jp/mansion/city/1619.html",
+        kind="mansion",
+        city_id="1619",
+        page_no=1,
+    )
+    row = rows[0]
+    assert row.price_or_rent_text == ""
+    assert row.area_text == ""
+    assert row.layout_text == ""
+    assert row.floor_text == ""
+    assert row.direction_text == ""
 
 
 def test_parse_list_page_mansion_building_name_keeps_original_text() -> None:


### PR DESCRIPTION
### Motivation
- Upstream raw extraction sometimes produced partial "exact" sale rows even when the source was mosaic or missing fields, causing downstream records to carry spurious exact values. 
- The goal is to ensure `mansion` (分譲) rows are exact only when all five key fields are present so downstream layers (`master_import` → `sale_listings` → `attach` → `summary` → public/dist/WEB) keep the same meaning. 
- ㎡単価 must remain a computed field using price ÷ area and only be present for exact rows. 

### Description
- Added a mosaic-detection helper and logic in `scripts/mansion_review_crawl_to_csv.py` to detect mosaic hints (`万円台`, `無料会員`, `モザイク`, `会員登録`, `ログイン`) anywhere in the row. 
- Changed `_extract_mansion_row` so that a row is treated as exact only when `価格/面積/間取り/所在階/向き` are all present, otherwise it returns empty fields (mosaic). 
- Kept ㎡単価 calculation (`price ÷ area`) and emit it only for exact rows. 
- Updated `tests/test_mansion_review_crawl_to_csv.py` to reflect the new behavior and added a test verifying partial rows are treated as mosaic. 

### Testing
- Ran `pytest -q tests/test_mansion_review_crawl_to_csv.py` and the tests passed. 
- Ran `pytest -q tests/test_mansion_review_crawl_to_csv.py tests/test_building_summaries.py` and both sets passed. 
- Attempted an automated `run_crawl` smoke run to fetch live pages, but network proxy returned `403 Forbidden`, so live site verification could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddd46da43c832681c62d1375375068)