### PR TITLE
Fix mansion_review_facts attach when canonical buildings are split by chome notation

### DIFF
--- a/src/tatemono_map/building_registry/matcher.py
+++ b/src/tatemono_map/building_registry/matcher.py
@@ -109,6 +109,27 @@ def _pick_strong_unique(candidates: list[tuple[str, float, float, float]], varia
     return MatchResult(None, "address_candidates_low_confidence", top_ids, top_scores, variant)
 
 
+def _pick_equivalent_duplicate(
+    candidates: list[tuple[str, str, str]],
+    *,
+    normalized_name: str,
+    normalized_address: str,
+    variant: str,
+) -> MatchResult | None:
+    if len(candidates) < 2:
+        return None
+    if not normalized_name or not normalized_address:
+        return None
+    if any((name or "") != normalized_name for _building_id, name, _addr in candidates):
+        return None
+    if any((addr or "") != normalized_address for _building_id, _name, addr in candidates):
+        return None
+    picked_id = sorted(building_id for building_id, _name, _addr in candidates)[0]
+    candidate_ids = [building_id for building_id, _name, _addr in sorted(candidates, key=lambda row: row[0])[:3]]
+    candidate_scores = [1.0 for _ in candidate_ids]
+    return MatchResult(picked_id, "address_equivalent_duplicate", candidate_ids, candidate_scores, variant)
+
+
 def match_building(conn: Any, normalized_name: str, normalized_address: str) -> MatchResult:
     if _has_multi_lot_or_range(normalized_address):
         return MatchResult(None, "address_multi_or_range", [], [])
@@ -142,6 +163,14 @@ def match_building(conn: Any, normalized_name: str, normalized_address: str) -> 
         matched = [row for row in addr_rows if normalize_address_for_matching(row[2] or "") == variant]
         if not matched:
             continue
+        equivalent_duplicate = _pick_equivalent_duplicate(
+            [(row[0], row[1] or "", normalize_address_for_matching(row[2] or "")) for row in matched],
+            normalized_name=normalized_name,
+            normalized_address=variant,
+            variant=variant if idx > 0 else "",
+        )
+        if equivalent_duplicate is not None:
+            return equivalent_duplicate
         if len(matched) == 1:
             name_score = _score_name(normalized_name, matched[0][1] or "")
             if _has_series_suffix_conflict(normalized_name, matched[0][1] or ""):

--- a/tests/test_building_matcher_variants.py
+++ b/tests/test_building_matcher_variants.py
@@ -192,3 +192,55 @@ def test_matcher_blocks_suffix_conflict_even_when_address_exact(tmp_path: Path) 
 
     assert result.building_id is None
     assert result.reason == "name_suffix_conflict"
+
+
+def test_ingest_facts_attaches_when_canonical_is_split_only_by_chome_notation(tmp_path: Path) -> None:
+    db_path = tmp_path / "split_chome.sqlite3"
+    _seed(db_path, "サンレリウス小倉駅南,福岡県北九州市小倉北区鍛冶町2丁目5番8号,ui:a,\n")
+
+    conn = connect(str(db_path))
+    conn.execute(
+        """
+        INSERT INTO buildings(
+            building_id, canonical_name, canonical_address, norm_name, norm_address, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        """,
+        (
+            "manual-split",
+            "サンレリウス小倉駅南",
+            "北九州市小倉北区鍛冶町二丁目5番8号",
+            "サンレリウス小倉駅南",
+            "北九州市小倉北区鍛冶町2-5-8",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    csv_path = tmp_path / "facts.csv"
+    csv_path.write_text(
+        "building_name,address,evidence_id,structure,built_year_month,property_kind\n"
+        "サンレリウス小倉駅南,福岡県北九州市小倉北区鍛冶町2丁目5番8号,mansion_review:https://www.mansion-review.jp/mansion/1638299.html,RC,2009-02,bunjo\n",
+        encoding="utf-8",
+    )
+    report = ingest_building_facts_csv(str(db_path), str(csv_path), source="mansion_review_facts", merge="fill_only")
+    assert report.matched == 1
+    assert report.unresolved == 0
+
+    conn = connect(str(db_path))
+    attached = conn.execute(
+        """
+        SELECT b.canonical_name, b.structure, b.built_year_month, b.property_kind
+        FROM building_sources s
+        JOIN buildings b ON b.building_id = s.building_id
+        WHERE s.source='mansion_review_facts'
+          AND s.evidence_id='mansion_review:https://www.mansion-review.jp/mansion/1638299.html'
+        """
+    ).fetchone()
+    conn.close()
+
+    assert attached is not None
+    assert attached["canonical_name"] == "サンレリウス小倉駅南"
+    assert attached["structure"] == "RC"
+    assert attached["built_year_month"] == "2009-02"
+    assert attached["property_kind"] == "bunjo"


### PR DESCRIPTION
### Motivation
- mansion_review の facts が `2丁目` / `二丁目` の丁目表記ゆれで canonical テーブルに重複があるときに attach されない問題を修正するための最小差分対応です。 
- 対象は facts 抽出はできているが `building_sources` に `mansion_review_facts` が入らないケースで、既存のマッチロジックを壊さないことを優先します。

### Description
- `src/tatemono_map/building_registry/matcher.py` に `_pick_equivalent_duplicate` を追加し、候補群が全て同一の `normalized_name` と同一の `normalized_address` に正規化される明確な同値重複時に決定論的な `building_id` を返す分岐を `match_building` の候補処理前に挿入しました。 
- 上記差分は曖昧マッチや suffix conflict の既存ガードを維持したうえで限定的にのみ適用されます。 
- 回帰テストとして `tests/test_building_matcher_variants.py` に `test_ingest_facts_attaches_when_canonical_is_split_only_by_chome_notation` を追加し、`サンレリウス小倉駅南` の `2丁目` / `二丁目` split 再現で `mansion_review_facts` が attach され `structure` / `built_year_month` / `property_kind` が更新されることを検証しています。 
- 変更ファイル: `src/tatemono_map/building_registry/matcher.py`, `tests/test_building_matcher_variants.py`。

### Testing
- 実行したテストは `pytest -q tests/test_building_matcher_variants.py::test_ingest_facts_attaches_when_canonical_is_split_only_by_chome_notation tests/test_building_matcher_variants.py::test_matcher_blocks_suffix_conflict_even_when_address_exact` で、2 件とも成功しました（`2 passed`）。
- 影響範囲を確認するために `pytest -q tests/test_ingest_building_facts.py tests/test_building_matcher_variants.py` を実行し、関連テスト群はすべて成功しました（`19 passed`）。
- 実環境 DB の直接確認はこの実行環境で `data/tatemono_map.sqlite3` にテーブルが存在しなかったためできませんでしたが、上記ユニットテストで再現ケースは検証済みです。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7327447483269b201b876e93087b)